### PR TITLE
ci: run golangci-lint in the test job again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
     - name: Run go vet
       run: go vet ./...
 
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@v8
+      with:
+        version: latest
+        args: --timeout=5m
+
     - name: Run unit tests
       run: go test -v -race -coverprofile=coverage-unit.out ./pkg/...
 
@@ -61,5 +67,3 @@ jobs:
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false
-
-# Linting runs locally via the pre-commit hook (golangci-lint), not in CI.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,17 +9,15 @@ linters:
     - ineffassign
     - gocritic
     - misspell
-
-linters-settings:
-  gocritic:
-    disabled-checks:
-      - commentFormatting
-
-issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - errcheck
+  settings:
+    gocritic:
+      disabled-checks:
+        - commentFormatting
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - errcheck
 
 run:
   timeout: 3m


### PR DESCRIPTION
Re-adds golangci-lint to CI (removed earlier when it was incompatible). Now runs as a step in the Test job alongside `go vet`, using golangci-lint-action@v8 (v2, matches .golangci.yml) on Go 1.25. All prior findings are already fixed, so it runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)