### PR TITLE
docs: minimize README code, make examples consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EVE ESI Client
 
-[![Go Version](https://img.shields.io/badge/Go-1.21+-00ADD8?style=flat&logo=go)](https://go.dev/)
+[![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?style=flat&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 **Production-ready ESI (EVE Swagger Interface) client infrastructure for EVE Online third-party applications.**
@@ -48,227 +48,59 @@
 
 ## Quick Start
 
-### Integrated Client (Available Now)
+Create a client and make a request — rate limiting and caching happen automatically:
 
 ```go
-package main
+redisClient := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+defer redisClient.Close()
 
-import (
-    "context"
-    "fmt"
-    "io"
-    "log"
-    
-    "github.com/Sternrassler/eve-esi-client/pkg/client"
-    "github.com/redis/go-redis/v9"
-)
+esiClient, _ := client.New(client.DefaultConfig(redisClient, "MyApp/1.0 (contact@example.com)"))
+defer esiClient.Close()
 
-func main() {
-    // Create Redis client
-    redisClient := redis.NewClient(&redis.Options{
-        Addr: "localhost:6379",
-    })
-    defer redisClient.Close()
-    
-    // Create ESI client with default configuration
-    cfg := client.DefaultConfig(redisClient, "MyApp/1.0.0 (contact@example.com)")
-    esiClient, err := client.New(cfg)
-    if err != nil {
-        log.Fatalf("Failed to create ESI client: %v", err)
-    }
-    defer esiClient.Close()
-    
-    // Make a request (automatic rate limiting + caching)
-    ctx := context.Background()
-    resp, err := esiClient.Get(ctx, "/v1/status/")
-    if err != nil {
-        log.Fatalf("Request failed: %v", err)
-    }
-    defer resp.Body.Close()
-    
-    // Read response
-    body, _ := io.ReadAll(resp.Body)
-    fmt.Printf("ESI Status: %s\n", body)
-}
+resp, _ := esiClient.Get(context.Background(), "/v1/status/")
+defer resp.Body.Close()
 ```
 
-See [examples/](examples/) for complete, runnable usage examples.
+→ Full runnable program: **[examples/library-usage/](examples/library-usage/)**
 
-### Foundation Components (Also Available Separately)
+### Foundation Components (also usable standalone)
 
-You can also use the Rate Limiter and Cache Manager as standalone components if needed.
+The Rate Limiter and Cache Manager can be used on their own, without the integrated client:
 
-#### Rate Limit Tracker
+- **Rate Limit Tracker** — proactively blocks requests when ESI's error budget runs low. See **[examples/ratelimit-usage/](examples/ratelimit-usage/)**.
+- **Cache Manager** — Redis-backed cache with ETag / conditional-request handling. See **[examples/cache-usage/](examples/cache-usage/)**.
 
-```go
-package main
+### Service Mode (HTTP Proxy)
 
-import (
-    "context"
-    "github.com/Sternrassler/eve-esi-client/pkg/ratelimit"
-    "github.com/redis/go-redis/v9"
-    "github.com/rs/zerolog"
-    "os"
-)
-
-func main() {
-    redisClient := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
-    logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
-    tracker := ratelimit.NewTracker(redisClient, logger)
-    
-    ctx := context.Background()
-    
-    // Check if request should be allowed
-    allowed, err := tracker.ShouldAllowRequest(ctx)
-    if !allowed {
-        // Request blocked - wait for rate limit reset
-        state, _ := tracker.GetState(ctx)
-        logger.Warn().
-            Int("errorsRemaining", state.ErrorsRemaining).
-            Msg("Rate limit reached - request blocked")
-        return
-    }
-    
-    // Make your ESI request...
-    // resp, err := http.Get("https://esi.evetech.net/...")
-    
-    // Update tracker from ESI response headers
-    // tracker.UpdateFromHeaders(ctx, resp.Header)
-}
-```
-
-#### Cache Manager
-
-```go
-package main
-
-import (
-    "context"
-    "github.com/Sternrassler/eve-esi-client/pkg/cache"
-    "github.com/redis/go-redis/v9"
-    "net/http"
-)
-
-func main() {
-    redisClient := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
-    manager := cache.NewManager(redisClient)
-    
-    ctx := context.Background()
-    endpoint := "/v1/markets/10000002/orders/"
-    params := map[string]string{"order_type": "sell"}
-    
-    // Try cache first
-    cacheKey := cache.GenerateKey(endpoint, params)
-    entry, err := manager.Get(ctx, cacheKey)
-    
-    if err == nil && !entry.IsExpired() {
-        // Cache hit - use cached response
-        println("Cache hit!")
-        // Use entry.Body, entry.StatusCode, etc.
-        return
-    }
-    
-    // Cache miss - make request
-    req, _ := http.NewRequest("GET", "https://esi.evetech.net"+endpoint, nil)
-    
-    // Add conditional headers if we have a cached entry
-    if entry != nil {
-        cache.AddConditionalHeaders(req, entry)
-    }
-    
-    resp, _ := http.DefaultClient.Do(req)
-    defer resp.Body.Close()
-    
-    // Convert response to cache entry and store
-    newEntry, _ := cache.ResponseToEntry(resp, endpoint, params)
-    manager.Set(ctx, cacheKey, newEntry)
-}
-```
-
-See [examples/cache-usage/](examples/cache-usage/) for complete standalone examples.
-
-### Service Mode (HTTP Proxy) - Coming in Phase 2
-
-```bash
-# Coming in Phase 2
-# docker run -p 8080:8080 \
-#     -e REDIS_URL=redis:6379 \
-#     ghcr.io/sternrassler/eve-esi-client:latest
-```
+*Coming in Phase 2* — a containerized HTTP proxy (`ghcr.io/sternrassler/eve-esi-client`).
 
 ## Installation
 
-### As Library (Complete Client Available Now)
-
 ```bash
-# Install full ESI client with integrated components
+# Full ESI client with integrated components
 go get github.com/Sternrassler/eve-esi-client/pkg/client
 
-# Or install individual components
+# Or individual components
 go get github.com/Sternrassler/eve-esi-client/pkg/ratelimit
 go get github.com/Sternrassler/eve-esi-client/pkg/cache
 ```
 
-### As Service (Docker)
-
-```yaml
-# docker-compose.yml
-services:
-  esi-proxy:
-    image: ghcr.io/sternrassler/eve-esi-client:latest
-    ports:
-      - "8080:8080"
-    environment:
-      REDIS_URL: redis:6379
-      LOG_LEVEL: info
-    depends_on:
-      - redis
-  
-  redis:
-    image: redis:7-alpine
-    volumes:
-      - redis-data:/data
-
-volumes:
-  redis-data:
-```
-
 ## Configuration
 
-### Library Mode
+`client.DefaultConfig(redis, userAgent)` returns sensible defaults; override fields as needed:
 
-```go
-config := client.Config{
-    // Required
-    Redis:     redisClient,
-    UserAgent: "MyApp/1.0 (contact@example.com)",
-    
-    // Rate Limiting
-    RateLimit:         10,   // requests per second
-    ErrorThreshold:    10,   // stop when < 10 errors remaining
-    
-    // Concurrency
-    MaxConcurrency:    5,    // parallel requests
-    
-    // Caching
-    MemoryCacheTTL:    60,   // seconds
-    RespectExpires:    true, // MUST be true (ESI requirement)
-    
-    // Retry
-    MaxRetries:        3,
-    InitialBackoff:    1,    // seconds
-}
-```
+| Field | Default | Purpose |
+|-------|---------|---------|
+| `UserAgent` | — (required) | ESI requires `AppName/Version (contact@example.com)` |
+| `RateLimit` | 10 | Requests per second |
+| `ErrorThreshold` | 10 | Block when fewer errors remain in the ESI budget |
+| `MaxConcurrency` | 5 | Max parallel requests |
+| `MemoryCacheTTL` | 60s | In-memory cache TTL |
+| `RespectExpires` | true | Honor ESI `expires` header (MUST stay true) |
+| `MaxRetries` | 3 | Retry attempts for transient errors |
+| `InitialBackoff` | 1s | First retry backoff (grows exponentially) |
 
-### Service Mode (Environment Variables)
-
-```bash
-REDIS_URL=localhost:6379
-RATE_LIMIT=10
-MAX_CONCURRENCY=5
-USER_AGENT="MyApp/1.0 (contact@example.com)"
-LOG_LEVEL=info
-```
+Full reference: **[docs/configuration.md](docs/configuration.md)**. Service-mode environment variables (`REDIS_URL`, `RATE_LIMIT`, `USER_AGENT`, `LOG_LEVEL`, …) are documented there too.
 
 ## ESI Compliance
 
@@ -284,15 +116,7 @@ This client strictly follows ESI rules to prevent bans:
 
 ESI uses **error rate limiting** instead of request rate limiting. The client automatically monitors ESI's error limit headers to prevent IP bans.
 
-### How It Works
-
-The rate limit tracker monitors two critical headers:
-- `X-ESI-Error-Limit-Remain`: Number of errors remaining before ESI blocks requests
-- `X-ESI-Error-Limit-Reset`: Seconds until the error limit resets
-
-### Thresholds
-
-The tracker operates in three states:
+The tracker watches `X-ESI-Error-Limit-Remain` / `X-ESI-Error-Limit-Reset` and operates in three states:
 
 | State | Errors Remaining | Behavior |
 |-------|-----------------|----------|
@@ -300,44 +124,13 @@ The tracker operates in three states:
 | 🟡 **Warning** | 20-49 | Requests throttled (1s delay between calls) |
 | 🔴 **Critical** | < 5 | All requests blocked until reset |
 
-### State Storage
-
-Rate limit state is shared across all client instances via Redis, ensuring coordinated behavior in multi-instance deployments.
-
-### Library Usage
-
-```go
-import (
-    "github.com/Sternrassler/eve-esi-client/pkg/ratelimit"
-    "github.com/redis/go-redis/v9"
-    "github.com/rs/zerolog"
-)
-
-// Create tracker
-redisClient := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
-logger := zerolog.New(os.Stderr)
-tracker := ratelimit.NewTracker(redisClient, logger)
-
-// Check if request should be allowed
-allowed, err := tracker.ShouldAllowRequest(ctx)
-if !allowed {
-    // Request blocked - wait for rate limit reset
-    return
-}
-
-// After receiving ESI response, update state from headers
-tracker.UpdateFromHeaders(ctx, resp.Header)
-```
-
-**Important**: Exceeding the error limit results in **permanent IP ban** from ESI. The tracker prevents this by proactively blocking requests when the limit becomes critical.
+State is shared across all client instances via Redis, ensuring coordinated behavior in multi-instance deployments. **Exceeding the error limit results in a permanent IP ban** — the integrated client handles this for you; for standalone use see **[examples/ratelimit-usage/](examples/ratelimit-usage/)**.
 
 ## Error Handling & Retry Logic
 
-The client implements intelligent retry logic with exponential backoff to handle transient errors while protecting against wasting the error budget.
+The client retries transient errors with exponential backoff while never wasting the error budget on client errors.
 
 ### Error Classification
-
-All errors are classified into four categories:
 
 | Error Class | HTTP Status | Retry? | Description |
 |------------|-------------|--------|-------------|
@@ -346,161 +139,52 @@ All errors are classified into four categories:
 | **Rate Limit** | 520 | ✅ Yes | Endpoint-specific rate limit exceeded |
 | **Network** | - | ✅ Yes | Connection timeouts, DNS failures, etc. |
 
-### Retry Strategies
+### Retry Strategy
 
-Different error classes use different retry strategies:
+Retries use exponential backoff with ±20% jitter (to avoid thundering herd) and respect `context` cancellation/timeouts:
 
-**Server Errors (5xx)**
-- Max Attempts: 3
-- Initial Backoff: 1s
-- Max Backoff: 10s
-- Multiplier: 2.0x
+- **Server (5xx)**: 3 attempts, 1s → 10s backoff
+- **Rate Limit (520)**: 3 attempts, 5s → 60s backoff (longer wait)
+- **Network**: 3 attempts, 2s → 30s backoff
 
-**Rate Limit (520)**
-- Max Attempts: 3
-- Initial Backoff: 5s (longer wait)
-- Max Backoff: 60s
-- Multiplier: 2.0x
+**Client errors (4xx) are never retried** — retrying can't fix an invalid request and would waste the error budget (risking an IP ban). Errors are surfaced as `client.ErrRetryExhausted` and `client.ErrContextCancelled` for precise handling.
 
-**Network Errors**
-- Max Attempts: 3
-- Initial Backoff: 2s
-- Max Backoff: 30s
-- Multiplier: 2.0x
-
-### Exponential Backoff with Jitter
-
-The client uses exponential backoff with ±20% jitter to prevent thundering herd:
-
-```
-Attempt 1: Immediate
-Attempt 2: Wait ~1s (0.8s - 1.2s with jitter)
-Attempt 3: Wait ~2s (1.6s - 2.4s with jitter)
-```
-
-### Context Cancellation
-
-All retry operations respect context cancellation, allowing you to set timeouts:
-
-```go
-ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-defer cancel()
-
-resp, err := client.Get(ctx, "/v1/status/")
-if errors.Is(err, client.ErrContextCancelled) {
-    // Request cancelled or timed out
-}
-```
-
-### Why NO Retry for 4xx?
-
-**Client errors (4xx) are NEVER retried** because:
-1. They count against your error budget
-2. Retrying won't fix the problem (invalid request)
-3. Wasting error budget can lead to IP ban
-
-### Error Handling Example
-
-```go
-resp, err := client.Get(ctx, "/v1/markets/10000002/orders/")
-if err != nil {
-    if errors.Is(err, client.ErrRetryExhausted) {
-        // All retry attempts failed
-        log.Error().Err(err).Msg("Request failed after retries")
-    } else if errors.Is(err, client.ErrContextCancelled) {
-        // Context timeout or cancellation
-        log.Warn().Msg("Request cancelled")
-    } else {
-        // Other error (e.g., 4xx client error - no retry)
-        log.Error().Err(err).Msg("Request failed")
-    }
-    return
-}
-defer resp.Body.Close()
-```
+→ Error-handling and timeout patterns in context: **[examples/library-usage/](examples/library-usage/)**.
 
 ## Examples
 
-See [examples/](examples/) directory:
+Runnable examples in [examples/](examples/):
 
-- [Library Usage](examples/library-usage/) - Go import example
-- [Service Usage](examples/service-usage/) - HTTP client examples (Python, Node.js, curl)
-- [Pagination](examples/pagination/) - Batch fetching market data
+- **[library-usage/](examples/library-usage/)** — integrated client: config, request, caching, error handling
+- **[cache-usage/](examples/cache-usage/)** — standalone Cache Manager
+- **[ratelimit-usage/](examples/ratelimit-usage/)** — standalone Rate Limit Tracker
+
+*(Phase 2 will add service-mode and pagination examples.)*
 
 ## Development
 
 ```bash
-# Clone repository
 git clone https://github.com/Sternrassler/eve-esi-client.git
 cd eve-esi-client
-
-# Install dependencies
 go mod download
-
-# Run tests
-make test
-
-# Run linter
-make lint
-
-# Start development service
-make run
+make test    # run tests
+make lint    # run linter
+make run     # start development service
 ```
 
 ## Health Checks & Logging
 
-### Health Checks
+### Health Checks (Service Mode)
 
-#### `/health` - Basic Health Check
-Returns `200 OK` when service is running.
-
-```bash
-curl http://localhost:8080/health
-# Response: OK
-```
-
-#### `/ready` - Readiness Check
-Checks critical dependencies (Redis connection, rate limit state).
-
-```bash
-curl http://localhost:8080/ready
-# Response: OK (200) or Service Unavailable (503)
-```
+- `GET /health` — basic liveness, returns `200 OK`.
+- `GET /ready` — readiness; checks Redis connection and rate-limit state (`200` or `503`).
 
 ### Structured Logging
 
-The client uses [zerolog](https://github.com/rs/zerolog) for structured JSON logging.
+The client uses [zerolog](https://github.com/rs/zerolog) for structured JSON logging via the `pkg/logging` package (`logging.Setup` / `logging.NewLogger`).
 
-#### Log Levels
-- **Debug**: Cache operations, request flow, conditional requests
-- **Info**: Successful requests, 304 responses, rate limit updates
-- **Warn**: Rate limit warnings, retry attempts, non-critical errors
-- **Error**: Failed requests, critical rate limit blocks, service errors
-
-#### Configuration
-
-```go
-import "github.com/Sternrassler/eve-esi-client/pkg/logging"
-
-// Setup global logger
-logger := logging.Setup(logging.Config{
-    Level:  logging.LevelInfo,
-    Pretty: false, // Set to true for human-readable console output
-})
-
-// Create component logger
-logger := logging.NewLogger("my-component")
-logger.Info().Str("key", "value").Msg("message")
-```
-
-#### Log Context Fields
-- `endpoint` - ESI endpoint path
-- `status_code` - HTTP status code
-- `duration` - Request duration
-- `error_class` - Error classification
-- `cache_hit` - Cache hit indicator
-- `errors_remaining` - Current ESI error limit
-- `etag` - ETag for conditional requests
+- **Levels**: Debug (cache/request flow), Info (successful requests, 304s, rate-limit updates), Warn (rate-limit warnings, retries), Error (failed requests, critical blocks)
+- **Context fields**: `endpoint`, `status_code`, `duration`, `error_class`, `cache_hit`, `errors_remaining`, `etag`
 
 ## License
 

--- a/examples/library-usage/README.md
+++ b/examples/library-usage/README.md
@@ -1,339 +1,37 @@
 # Library Usage Example
 
-This example demonstrates how to use the EVE ESI Client as a Go library in your application.
+A complete, runnable program showing the integrated ESI client: configuration,
+making a request, automatic caching (ETag / 304), and error handling.
+
+The code lives in [`main.go`](main.go) — this README only explains how to run it.
 
 ## Prerequisites
 
-- Go 1.21 or higher
-- Redis server running (default: localhost:6379)
+- Go 1.25+
+- A Redis server (default: `localhost:6379`)
 
-## Quick Start
-
-### 1. Start Redis (if not already running)
+## Run
 
 ```bash
-# Using Docker
+# Start Redis if needed
 docker run -d -p 6379:6379 redis:7-alpine
 
-# Or using your local Redis installation
-redis-server
-```
-
-### 2. Run the Example
-
-```bash
-# From the repository root
+# Run the example
 cd examples/library-usage
 go run main.go
 ```
 
-### 3. Expected Output
+Override the Redis address via `REDIS_URL` if needed.
 
-```
-✅ Connected to Redis
-✅ ESI client initialized
+## What it demonstrates
 
-📊 Fetching market orders from region 10000002...
-✅ Retrieved 15234 market orders
+- Client initialization with `client.DefaultConfig` (User-Agent per ESI rules)
+- Making a request with automatic rate limiting and caching
+- A second request served from cache via a conditional request (304 Not Modified)
+- Error handling for an invalid endpoint
 
-📋 Sample Orders:
-─────────────────────────────────────────────────────────
-SELL | TypeID:    34 | Price:    100000.00 ISK | Volume:     1000
-SELL | TypeID:    35 | Price:    250000.00 ISK | Volume:      500
-BUY  | TypeID:    36 | Price:     95000.00 ISK | Volume:     2000
-SELL | TypeID:    37 | Price:    150000.00 ISK | Volume:      750
-SELL | TypeID:    38 | Price:    300000.00 ISK | Volume:      300
-─────────────────────────────────────────────────────────
+## See also
 
-🔄 Making second request (should use cache)...
-✅ 304 Not Modified - cache is working!
-
-🔍 Testing error handling with invalid endpoint...
-⚠️  ESI returned error status: 404
-
-📈 Example completed successfully!
-
-Key Features Demonstrated:
-  ✅ Automatic rate limiting
-  ✅ Redis-backed caching
-  ✅ ETag-based conditional requests
-  ✅ Error handling and retries
-  ✅ Structured logging
-  ✅ Prometheus metrics (exposed at /metrics)
-```
-
-## What This Example Demonstrates
-
-### 1. **ESI Client Initialization**
-
-```go
-// Create client with default configuration
-cfg := client.DefaultConfig(redisClient, "MyApp/1.0.0 (contact@example.com)")
-esiClient, err := client.New(cfg)
-```
-
-**Important**: The User-Agent must follow ESI requirements: `AppName/Version (contact@example.com)`
-
-### 2. **Configuration Options**
-
-```go
-cfg := client.DefaultConfig(redisClient, userAgent)
-
-// Customize settings
-cfg.MaxRetries = 3              // Retry failed requests up to 3 times
-cfg.InitialBackoff = 1 * time.Second  // Start with 1s backoff
-cfg.ErrorThreshold = 10         // Block when < 10 errors remaining
-cfg.MaxConcurrency = 5          // Max 5 parallel requests
-```
-
-### 3. **Making Requests**
-
-```go
-ctx := context.Background()
-resp, err := esiClient.Get(ctx, "/v1/markets/10000002/orders/")
-if err != nil {
-    log.Fatalf("Request failed: %v", err)
-}
-defer resp.Body.Close()
-```
-
-The client automatically handles:
-- ✅ Rate limit checking (prevents ESI bans)
-- ✅ Cache lookup (Redis)
-- ✅ Conditional requests (If-None-Match with ETag)
-- ✅ Response caching
-- ✅ Retry logic for server errors
-- ✅ Metrics collection
-
-### 4. **Handling Responses**
-
-```go
-// Check status code
-if resp.StatusCode != 200 {
-    body, _ := io.ReadAll(resp.Body)
-    log.Printf("Error: %d - %s", resp.StatusCode, string(body))
-    return
-}
-
-// Parse JSON
-var data interface{}
-body, _ := io.ReadAll(resp.Body)
-json.Unmarshal(body, &data)
-```
-
-### 5. **Caching Behavior**
-
-The client automatically:
-1. **Checks cache** before making ESI requests
-2. **Uses conditional requests** (If-None-Match) if cached data exists
-3. **Handles 304 Not Modified** by returning cached data
-4. **Updates cache** on successful 200 OK responses
-
-```
-Request 1: Cache Miss → ESI Request → Cache Store → Return Data
-Request 2: Cache Hit → Conditional Request → 304 Not Modified → Return Cached Data
-```
-
-### 6. **Error Handling**
-
-```go
-resp, err := esiClient.Get(ctx, endpoint)
-if err != nil {
-    // Handle errors:
-    // - Network errors (will retry)
-    // - Rate limit blocks
-    // - Context cancellation
-    return err
-}
-
-// Check HTTP status
-switch resp.StatusCode {
-case 200:
-    // Success
-case 304:
-    // Not Modified (cache valid)
-case 404:
-    // Not Found (client error - no retry)
-case 500:
-    // Server Error (will retry automatically)
-case 520:
-    // ESI Rate Limit (will retry with backoff)
-}
-```
-
-### 7. **Rate Limit Protection**
-
-The client monitors ESI error headers and **automatically blocks requests** when approaching the error limit:
-
-```
-Errors Remaining ≥ 50: ✅ Normal operation
-Errors Remaining 20-49: ⚠️  Throttled (1s delay)
-Errors Remaining < 5:  🛑 Blocked (wait for reset)
-```
-
-**Why This Matters**: Exceeding the ESI error limit results in **permanent IP ban**.
-
-## Environment Variables
-
-```bash
-# Redis connection
-export REDIS_URL="localhost:6379"
-export REDIS_PASSWORD=""  # Optional
-
-# Application settings (optional)
-export LOG_LEVEL="info"   # debug, info, warn, error
-```
-
-## Integration in Your Application
-
-### Minimal Example
-
-```go
-package main
-
-import (
-    "context"
-    "log"
-    
-    "github.com/Sternrassler/eve-esi-client/pkg/client"
-    "github.com/redis/go-redis/v9"
-)
-
-func main() {
-    // Setup
-    redisClient := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
-    defer redisClient.Close()
-    
-    cfg := client.DefaultConfig(redisClient, "MyApp/1.0.0 (contact@example.com)")
-    esiClient, _ := client.New(cfg)
-    defer esiClient.Close()
-    
-    // Make request
-    resp, err := esiClient.Get(context.Background(), "/v1/status/")
-    if err != nil {
-        log.Fatal(err)
-    }
-    defer resp.Body.Close()
-    
-    log.Printf("ESI Status: %d", resp.StatusCode)
-}
-```
-
-### With Timeout Context
-
-```go
-// Set 30 second timeout
-ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-defer cancel()
-
-resp, err := esiClient.Get(ctx, "/v1/markets/10000002/orders/")
-if err != nil {
-    if errors.Is(err, context.DeadlineExceeded) {
-        log.Println("Request timed out")
-    }
-    return err
-}
-```
-
-### Concurrent Requests
-
-```go
-var wg sync.WaitGroup
-endpoints := []string{
-    "/v1/markets/10000002/orders/",
-    "/v1/markets/10000042/orders/",
-    "/v1/markets/10000043/orders/",
-}
-
-for _, endpoint := range endpoints {
-    wg.Add(1)
-    go func(ep string) {
-        defer wg.Done()
-        
-        resp, err := esiClient.Get(context.Background(), ep)
-        if err != nil {
-            log.Printf("Error fetching %s: %v", ep, err)
-            return
-        }
-        defer resp.Body.Close()
-        
-        log.Printf("Fetched %s: %d", ep, resp.StatusCode)
-    }(endpoint)
-}
-
-wg.Wait()
-```
-
-**Note**: The client handles concurrency limits automatically (`MaxConcurrency` setting).
-
-## Monitoring
-
-### Prometheus Metrics
-
-The client exposes Prometheus metrics for monitoring:
-
-```go
-import "github.com/prometheus/client_golang/prometheus/promhttp"
-
-// Expose metrics endpoint
-http.Handle("/metrics", promhttp.Handler())
-go http.ListenAndServe(":9090", nil)
-```
-
-Available metrics:
-- `esi_requests_total` - Total requests by endpoint and status
-- `esi_request_duration_seconds` - Request latency histogram
-- `esi_errors_total` - Errors by classification
-- `esi_cache_hits_total` - Cache hit rate
-- `esi_errors_remaining` - Current ESI error limit
-- `esi_rate_limit_blocks_total` - Requests blocked by rate limiter
-
-### Structured Logging
-
-The client uses structured JSON logging (zerolog):
-
-```json
-{"level":"info","component":"esi-client","endpoint":"/v1/status/","status":200,"duration":123,"time":"2025-01-01T12:00:00Z","message":"Request completed"}
-```
-
-## Best Practices
-
-1. **Always set a User-Agent** with contact information (ESI requirement)
-2. **Use context with timeouts** to prevent hanging requests
-3. **Handle all status codes** properly (don't assume 200 OK)
-4. **Monitor metrics** to detect issues early
-5. **Set appropriate `ErrorThreshold`** (default 10 is safe)
-6. **Use shared Redis** for distributed deployments (rate limit coordination)
-7. **Close client on shutdown** to cleanup resources
-
-## Troubleshooting
-
-### "Request blocked: rate limit critical"
-
-**Cause**: ESI error limit is critically low (< 5 errors remaining).
-
-**Solution**: Wait for the error limit to reset (usually 60 seconds). Check logs for what's causing errors.
-
-### "Cache miss" for every request
-
-**Cause**: Redis connection issue or TTL too short.
-
-**Solution**: Verify Redis is running and accessible. Check `Expires` headers from ESI.
-
-### High retry rate
-
-**Cause**: ESI server errors (5xx) or rate limits (520).
-
-**Solution**: This is normal during ESI maintenance. Adjust `MaxRetries` and `InitialBackoff` if needed.
-
-## Further Reading
-
-- [ESI Documentation](https://docs.esi.evetech.net/)
-- [ESI Best Practices](https://docs.esi.evetech.net/docs/best_practices.html)
 - [Project README](../../README.md)
 - [Configuration Guide](../../docs/configuration.md)
-- [Monitoring Guide](../../docs/monitoring.md)
-
-## License
-
-MIT - See [LICENSE](../../LICENSE)
+- [Troubleshooting Guide](../../docs/troubleshooting.md)

--- a/examples/ratelimit-usage/main.go
+++ b/examples/ratelimit-usage/main.go
@@ -1,0 +1,63 @@
+// Standalone example for the ESI rate-limit tracker.
+//
+// The Tracker monitors ESI's error-limit headers (shared across instances via
+// Redis) and decides whether a request is currently safe to send — preventing
+// the permanent IP ban that follows from exhausting the ESI error budget.
+//
+// Run (requires Redis on localhost:6379):
+//
+//	cd examples/ratelimit-usage && go run main.go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/Sternrassler/eve-esi-client/pkg/ratelimit"
+	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
+)
+
+func main() {
+	redisClient := redis.NewClient(&redis.Options{
+		Addr: "localhost:6379",
+		DB:   0,
+	})
+	defer func() { _ = redisClient.Close() }()
+
+	ctx := context.Background()
+	if err := redisClient.Ping(ctx).Err(); err != nil {
+		fmt.Printf("Redis not available: %v\n", err)
+		fmt.Println("This example requires a running Redis instance on localhost:6379")
+		return
+	}
+
+	logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
+	tracker := ratelimit.NewTracker(redisClient, logger)
+
+	// Ask the tracker whether a request is allowed under the current error budget.
+	allowed, err := tracker.ShouldAllowRequest(ctx)
+	if err != nil {
+		fmt.Printf("Failed to check rate limit: %v\n", err)
+		return
+	}
+
+	if !allowed {
+		state, _ := tracker.GetState(ctx)
+		fmt.Printf("🛑 Request blocked — errors remaining: %d (resets at %s)\n",
+			state.ErrorsRemaining, state.ResetAt.Format("15:04:05"))
+		return
+	}
+	fmt.Println("✅ Request allowed by rate limiter")
+
+	// ... make your ESI HTTP request here ...
+	//
+	// After receiving the response, feed ESI's error-limit headers back so the
+	// shared state stays in sync across all instances:
+	//
+	//   blocked, err := tracker.UpdateFromHeaders(ctx, resp.Header)
+
+	state, _ := tracker.GetState(ctx)
+	fmt.Printf("Current state — errors remaining: %d\n", state.ErrorsRemaining)
+}


### PR DESCRIPTION
## Summary
- **README code minimized**: was ~189 lines of Go across 8 blocks (several inconsistent with the real API). Now one minimal Quick Start snippet; everything else is prose + links to runnable examples / docs/configuration.md.
- **Examples section fixed**: previously linked to non-existent `examples/service-usage` and `examples/pagination` and omitted `cache-usage`. Now lists the three real examples.
- **New** `examples/ratelimit-usage/`: standalone Rate Limit Tracker (link target for the Foundation section), builds + lints clean.
- **Slimmed** `examples/library-usage/README.md`: from a 300-line duplicate mini-doc (15 code snippets, stale Prometheus/monitoring references) to a focused run guide.

## Test Plan
- [x] README has exactly 1 Go block; all example/doc links resolve
- [x] No Prometheus/monitoring/Go-1.21 leftovers
- [x] `go build/vet ./...`, `golangci-lint run` (0), examples build

🤖 Generated with [Claude Code](https://claude.com/claude-code)