### PR TITLE
docs: align pagination/service-mode claims with code; fix esi-proxy body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **Prometheus metrics feature** — `pkg/metrics`, the promauto instrumentation across `pkg/cache`, `pkg/client`, `pkg/ratelimit`, the `/metrics` endpoint, monitoring docs, and the `prometheus/client_golang` dependency. Observability now relies on structured logging.
+- **Architecture Decision Records** and their enforcement (pre-commit/CI ADR checks, `check-adr*` scripts, ADR policy in copilot-instructions).
+
+### Changed
+- README slimmed to a single Quick Start snippet; all other code moved to runnable `examples/`. Docs pruned to `configuration.md` + `troubleshooting.md`.
+- Roadmap claims aligned with the code: pagination (`pkg/pagination`) and the HTTP proxy (`cmd/esi-proxy`) are documented as experimental rather than "Phase 2".
+
+### Added
+- `examples/ratelimit-usage/` — standalone rate-limit tracker example.
+
+### Fixed
+- `cmd/esi-proxy` now copies the upstream ESI response body (was a `TODO` stub).
+- CI builds on Go 1.25 and runs `golangci-lint` v2 (matching `.golangci.yml`); fixed all lint findings and `gofmt`.
+
+## [0.4.0] - 2026-05-25
+
+### Added
+- Per-second rate limiter and concurrency semaphore enforcement.
+- Cache-Control handling (`no-store` / `max-age`).
+
+### Fixed
+- Atomic error-budget decrement with context-aware throttling.
+- Auth-aware cache key (hashes the `Authorization` header).
+- Retry resends the request body via `GetBody`.
+- Pagination `FetchPage` appends the `page` param without dropping existing query values.
+
+## [0.3.0] - 2025-11-04
+
+### Added
+- Parallel `BatchFetcher` with worker pool for paginated ESI endpoints (`pkg/pagination`).
+
 ## [0.2.0] - 2025-10-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,13 +9,12 @@
 
 - 🚀 **High Performance**: Redis-backed caching with ETag support
 - 🛡️ **Ban Protection**: ESI error rate limiting (3-tier threshold system)
-- 📊 **Pagination Support**: *(Coming in Phase 2)* Parallel page fetching with worker pools
+- 📊 **Pagination**: parallel page fetching with worker pools — *experimental*, standalone in `pkg/pagination` (not yet integrated into the client)
 - 🔄 **Cache Optimization**: ETag (If-None-Match), `expires` header compliance, 304 Not Modified
 - 📈 **Observability**: structured logging (Zerolog)
-- 🔌 **Flexible**: *(Phase 1)* Go library mode | *(Phase 2)* HTTP service mode
+- 🔌 **Modes**: Go library mode (stable) | HTTP service-mode proxy (*experimental*, `cmd/esi-proxy`)
 
-**Phase 1 Status (Foundation)**: ✅ **Rate Limiter, Cache Manager & ESI Client Core COMPLETED**  
-**Next**: Pagination Support (Issue #4) and Service Mode (Phase 2)
+**Status**: ✅ Rate Limiter, Cache Manager and the ESI Client Core are stable. Pagination (`pkg/pagination`) and the HTTP service-mode proxy (`cmd/esi-proxy`) exist but are **experimental** — not yet integrated/hardened, and the proxy has no published container image.
 
 ## Architecture
 
@@ -72,7 +71,13 @@ The Rate Limiter and Cache Manager can be used on their own, without the integra
 
 ### Service Mode (HTTP Proxy)
 
-*Coming in Phase 2* — a containerized HTTP proxy (`ghcr.io/sternrassler/eve-esi-client`).
+An **experimental** HTTP proxy lives in [`cmd/esi-proxy/`](cmd/esi-proxy/): it exposes `/health`, `/ready`, and `/esi/...` (forwarding to ESI with automatic rate limiting + caching).
+
+```bash
+go run ./cmd/esi-proxy   # listens on :8080 (PORT env to override)
+```
+
+No container image is published yet, and it is not production-hardened.
 
 ## Installation
 
@@ -159,7 +164,7 @@ Runnable examples in [examples/](examples/):
 - **[cache-usage/](examples/cache-usage/)** — standalone Cache Manager
 - **[ratelimit-usage/](examples/ratelimit-usage/)** — standalone Rate Limit Tracker
 
-*(Phase 2 will add service-mode and pagination examples.)*
+The experimental `pkg/pagination` (batch fetcher) and `cmd/esi-proxy` (HTTP proxy) are not yet covered by dedicated examples.
 
 ## Development
 

--- a/cmd/esi-proxy/main.go
+++ b/cmd/esi-proxy/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -106,8 +107,8 @@ func esiProxyHandler(esiClient *client.Client) http.HandlerFunc {
 		w.WriteHeader(resp.StatusCode)
 
 		// Copy body
-		if _, err := w.Write([]byte("TODO: Copy response body")); err != nil {
-			log.Printf("Failed to write response: %v", err)
+		if _, err := io.Copy(w, resp.Body); err != nil {
+			log.Printf("Failed to copy response body: %v", err)
 		}
 	}
 }

--- a/pkg/pagination/doc.go
+++ b/pkg/pagination/doc.go
@@ -17,5 +17,5 @@
 //   - Collects results with progress logging
 //   - Handles errors gracefully (returns partial data)
 //
-// See ADR-008 for architecture decisions.
+// Status: standalone component — not yet wired into the integrated client.
 package pagination


### PR DESCRIPTION
## Summary
README advertised **pagination** and **HTTP service-mode** as *Coming in Phase 2*, but both already exist in the codebase — just not finished:
- `pkg/pagination` (BatchFetcher + worker pool) is implemented but **standalone, not integrated, untested** → documented as experimental.
- `cmd/esi-proxy` (HTTP proxy with /health, /ready, /esi/) exists but had a **stub bug**: it wrote the literal string `TODO: Copy response body` instead of the ESI response. Fixed with `io.Copy`. No container image is published → documented as experimental.

Also:
- `pkg/pagination/doc.go`: removed the dangling ADR-008 reference.
- `CHANGELOG.md`: added the missing **0.3.0** and **0.4.0** entries (derived from git history) and an **Unreleased** section recording the metrics/ADR removals and fixes. Historical entries left intact.

## Test Plan
- [x] `go build/vet ./...`, `gofmt`, `golangci-lint run` (0)
- [x] `go test ./pkg/... ./cmd/...` pass (incl. esi-proxy after the body fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)