### PR TITLE
test(pagination): add unit tests + runnable example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `examples/ratelimit-usage/` — standalone rate-limit tracker example.
+- `examples/pagination-usage/` — parallel batch-fetch example.
+- Unit tests for `pkg/pagination` (batch fetcher: single/multi-page, partial failure, config clamping, context cancellation).
 
 ### Fixed
 - `cmd/esi-proxy` now copies the upstream ESI response body (was a `TODO` stub).

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 
 - 🚀 **High Performance**: Redis-backed caching with ETag support
 - 🛡️ **Ban Protection**: ESI error rate limiting (3-tier threshold system)
-- 📊 **Pagination**: parallel page fetching with worker pools — *experimental*, standalone in `pkg/pagination` (not yet integrated into the client)
+- 📊 **Pagination**: parallel page fetching with worker pools (`pkg/pagination`, tested) — usable standalone with any `PageFetcher` (the client implements it); not yet wired into the client's high-level API
 - 🔄 **Cache Optimization**: ETag (If-None-Match), `expires` header compliance, 304 Not Modified
 - 📈 **Observability**: structured logging (Zerolog)
 - 🔌 **Modes**: Go library mode (stable) | HTTP service-mode proxy (*experimental*, `cmd/esi-proxy`)
 
-**Status**: ✅ Rate Limiter, Cache Manager and the ESI Client Core are stable. Pagination (`pkg/pagination`) and the HTTP service-mode proxy (`cmd/esi-proxy`) exist but are **experimental** — not yet integrated/hardened, and the proxy has no published container image.
+**Status**: ✅ Rate Limiter, Cache Manager and the ESI Client Core are stable. Pagination (`pkg/pagination`) is tested and usable standalone, but not yet wired into the client's high-level API. The HTTP service-mode proxy (`cmd/esi-proxy`) is **experimental** — not hardened, and has no published container image.
 
 ## Architecture
 
@@ -163,8 +163,9 @@ Runnable examples in [examples/](examples/):
 - **[library-usage/](examples/library-usage/)** — integrated client: config, request, caching, error handling
 - **[cache-usage/](examples/cache-usage/)** — standalone Cache Manager
 - **[ratelimit-usage/](examples/ratelimit-usage/)** — standalone Rate Limit Tracker
+- **[pagination-usage/](examples/pagination-usage/)** — parallel page fetching with the batch fetcher
 
-The experimental `pkg/pagination` (batch fetcher) and `cmd/esi-proxy` (HTTP proxy) are not yet covered by dedicated examples.
+The experimental `cmd/esi-proxy` (HTTP proxy) is not yet covered by a dedicated example.
 
 ## Development
 

--- a/examples/pagination-usage/main.go
+++ b/examples/pagination-usage/main.go
@@ -1,0 +1,71 @@
+// Standalone example for the ESI pagination batch fetcher.
+//
+// The BatchFetcher fetches all pages of a paginated ESI endpoint in parallel
+// using a configurable worker pool, handling partial failures gracefully and
+// returning whatever data was successfully retrieved.
+//
+// Run (requires Redis on localhost:6379 and a network connection to ESI):
+//
+//	cd examples/pagination-usage && go run main.go
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Sternrassler/eve-esi-client/pkg/client"
+	"github.com/Sternrassler/eve-esi-client/pkg/pagination"
+	"github.com/redis/go-redis/v9"
+)
+
+func main() {
+	redisClient := redis.NewClient(&redis.Options{
+		Addr: "localhost:6379",
+		DB:   0,
+	})
+	defer func() { _ = redisClient.Close() }()
+
+	ctx := context.Background()
+	if err := redisClient.Ping(ctx).Err(); err != nil {
+		fmt.Printf("Redis not available: %v\n", err)
+		fmt.Println("This example requires a running Redis instance on localhost:6379")
+		return
+	}
+
+	esiClient, err := client.New(client.DefaultConfig(redisClient, "EVE-ESI-Pagination-Example/1.0 (you@example.com)"))
+	if err != nil {
+		fmt.Printf("Failed to create ESI client: %v\n", err)
+		return
+	}
+
+	bf := pagination.NewBatchFetcher(esiClient, pagination.DefaultConfig())
+
+	const endpoint = "/v1/markets/10000002/orders/"
+	fmt.Printf("Fetching all pages from %s …\n", endpoint)
+
+	results, err := bf.FetchAllPages(ctx, endpoint)
+	if err != nil {
+		// Partial-data error: some pages failed but we still have what succeeded.
+		if strings.Contains(err.Error(), "partial data") {
+			fmt.Printf("Note: partial fetch — %v\n", err)
+		} else {
+			fmt.Printf("Fetch failed: %v\n", err)
+			return
+		}
+	}
+
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		fmt.Printf("Context cancelled: %v\n", err)
+		return
+	}
+
+	totalBytes := 0
+	for _, data := range results {
+		totalBytes += len(data)
+	}
+
+	fmt.Printf("Pages fetched : %d\n", len(results))
+	fmt.Printf("Total bytes   : %d\n", totalBytes)
+}

--- a/pkg/pagination/batch_fetcher_test.go
+++ b/pkg/pagination/batch_fetcher_test.go
@@ -1,0 +1,269 @@
+package pagination
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeFetcher is a thread-safe PageFetcher for testing.
+type fakeFetcher struct {
+	mu         sync.Mutex
+	totalPages int
+	// pageData maps pageNum -> data bytes; if absent, a default is generated.
+	pageData map[int][]byte
+	// pageErrors maps pageNum -> error to return for that page.
+	pageErrors map[int]error
+	callCount  int
+}
+
+func newFakeFetcher(totalPages int) *fakeFetcher {
+	return &fakeFetcher{
+		totalPages: totalPages,
+		pageData:   make(map[int][]byte),
+		pageErrors: make(map[int]error),
+	}
+}
+
+func (f *fakeFetcher) setPageData(pageNum int, data []byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.pageData[pageNum] = data
+}
+
+func (f *fakeFetcher) setPageError(pageNum int, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.pageErrors[pageNum] = err
+}
+
+func (f *fakeFetcher) calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.callCount
+}
+
+// FetchPage implements PageFetcher.
+func (f *fakeFetcher) FetchPage(_ context.Context, _ string, pageNum int) ([]byte, int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.callCount++
+
+	if err, ok := f.pageErrors[pageNum]; ok {
+		return nil, 0, err
+	}
+
+	if data, ok := f.pageData[pageNum]; ok {
+		return data, f.totalPages, nil
+	}
+
+	// Default: synthesise deterministic page data.
+	data := []byte(fmt.Sprintf(`{"page":%d}`, pageNum))
+	return data, f.totalPages, nil
+}
+
+// ---------------------------------------------------------------------------
+// 1. DefaultConfig / NewBatchFetcher clamping
+// ---------------------------------------------------------------------------
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.MaxConcurrency != 10 {
+		t.Errorf("MaxConcurrency: got %d, want 10", cfg.MaxConcurrency)
+	}
+	if cfg.Timeout != 15*time.Second {
+		t.Errorf("Timeout: got %v, want 15s", cfg.Timeout)
+	}
+	if cfg.BufferSize != 400 {
+		t.Errorf("BufferSize: got %d, want 400", cfg.BufferSize)
+	}
+}
+
+func TestNewBatchFetcher_ClampsNonPositiveFields(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Config
+		want Config
+	}{
+		{
+			name: "zero values clamped to defaults",
+			in:   Config{MaxConcurrency: 0, Timeout: 0, BufferSize: 0},
+			want: Config{MaxConcurrency: 10, Timeout: 15 * time.Second, BufferSize: 400},
+		},
+		{
+			name: "negative values clamped to defaults",
+			in:   Config{MaxConcurrency: -5, Timeout: -1, BufferSize: -100},
+			want: Config{MaxConcurrency: 10, Timeout: 15 * time.Second, BufferSize: 400},
+		},
+		{
+			name: "positive values preserved",
+			in:   Config{MaxConcurrency: 3, Timeout: 5 * time.Second, BufferSize: 50},
+			want: Config{MaxConcurrency: 3, Timeout: 5 * time.Second, BufferSize: 50},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeFetcher(1)
+			bf := NewBatchFetcher(f, tc.in)
+
+			if bf.config.MaxConcurrency != tc.want.MaxConcurrency {
+				t.Errorf("MaxConcurrency: got %d, want %d", bf.config.MaxConcurrency, tc.want.MaxConcurrency)
+			}
+			if bf.config.Timeout != tc.want.Timeout {
+				t.Errorf("Timeout: got %v, want %v", bf.config.Timeout, tc.want.Timeout)
+			}
+			if bf.config.BufferSize != tc.want.BufferSize {
+				t.Errorf("BufferSize: got %d, want %d", bf.config.BufferSize, tc.want.BufferSize)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. Single-page fast path
+// ---------------------------------------------------------------------------
+
+func TestFetchAllPages_SinglePage(t *testing.T) {
+	want := []byte(`{"items":[1,2,3]}`)
+	f := newFakeFetcher(1)
+	f.setPageData(1, want)
+
+	bf := NewBatchFetcher(f, DefaultConfig())
+	results, err := bf.FetchAllPages(context.Background(), "/v1/test/")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 page in results, got %d", len(results))
+	}
+	if string(results[1]) != string(want) {
+		t.Errorf("page 1 data: got %q, want %q", results[1], want)
+	}
+	if f.calls() != 1 {
+		t.Errorf("fetcher called %d times, want 1", f.calls())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3. Multiple pages — all pages present and correct
+// ---------------------------------------------------------------------------
+
+func TestFetchAllPages_MultiplePages(t *testing.T) {
+	const total = 5
+	f := newFakeFetcher(total)
+	for i := 1; i <= total; i++ {
+		f.setPageData(i, []byte(fmt.Sprintf(`{"page":%d,"data":"ok"}`, i)))
+	}
+
+	bf := NewBatchFetcher(f, DefaultConfig())
+	results, err := bf.FetchAllPages(context.Background(), "/v1/markets/")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != total {
+		t.Fatalf("expected %d pages, got %d", total, len(results))
+	}
+	for i := 1; i <= total; i++ {
+		want := []byte(fmt.Sprintf(`{"page":%d,"data":"ok"}`, i))
+		if string(results[i]) != string(want) {
+			t.Errorf("page %d: got %q, want %q", i, results[i], want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 4. First-page error
+// ---------------------------------------------------------------------------
+
+func TestFetchAllPages_FirstPageError(t *testing.T) {
+	f := newFakeFetcher(5)
+	f.setPageError(1, errors.New("network timeout"))
+
+	bf := NewBatchFetcher(f, DefaultConfig())
+	results, err := bf.FetchAllPages(context.Background(), "/v1/test/")
+
+	if results != nil {
+		t.Errorf("expected nil map on first-page error, got %v", results)
+	}
+	if err == nil {
+		t.Fatal("expected non-nil error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to fetch first page") {
+		t.Errorf("error message %q does not contain 'failed to fetch first page'", err.Error())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 5. Partial failure (one worker page fails)
+// ---------------------------------------------------------------------------
+
+func TestFetchAllPages_PartialFailure(t *testing.T) {
+	const total = 5
+	failedPage := 3
+
+	f := newFakeFetcher(total)
+	f.setPageError(failedPage, errors.New("upstream unavailable"))
+
+	bf := NewBatchFetcher(f, DefaultConfig())
+	results, err := bf.FetchAllPages(context.Background(), "/v1/markets/")
+
+	// Error must be present and mention partial data.
+	if err == nil {
+		t.Fatal("expected non-nil error for partial failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "partial data") {
+		t.Errorf("error %q does not contain 'partial data'", err.Error())
+	}
+
+	// Failed page must be absent from results.
+	if _, present := results[failedPage]; present {
+		t.Errorf("page %d should be absent from results (it failed)", failedPage)
+	}
+
+	// Fewer than total pages must be in the map.
+	if len(results) >= total {
+		t.Errorf("expected < %d pages in partial results, got %d", total, len(results))
+	}
+
+	// Page 1 must always be present (it succeeded).
+	if _, ok := results[1]; !ok {
+		t.Error("page 1 should be present in results")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 6. Context cancellation — must not hang
+// ---------------------------------------------------------------------------
+
+func TestFetchAllPages_ContextCancellation(t *testing.T) {
+	// Use a large totalPages so there are plenty of remaining pages in the queue.
+	const total = 100
+	f := newFakeFetcher(total)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+
+	bf := NewBatchFetcher(f, DefaultConfig())
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = bf.FetchAllPages(ctx, "/v1/markets/")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// completed without hanging — pass
+	case <-time.After(3 * time.Second):
+		t.Fatal("FetchAllPages did not return within 3s after context cancellation")
+	}
+}


### PR DESCRIPTION
## Summary
`pkg/pagination` was implemented but untested and example-less. This adds both.

- **Tests** (`pkg/pagination/batch_fetcher_test.go`): thread-safe fake `PageFetcher`; covers config defaults/clamping, single-page fast path, multi-page fetch, first-page error, partial failure (failed page omitted + 'partial data' error), and context cancellation. Deterministic, no network/Redis.
- **Example** (`examples/pagination-usage/`): runs `BatchFetcher.FetchAllPages` against a paginated ESI endpoint via the client (which implements `PageFetcher` through `FetchPage`).
- **Docs**: README now lists the pagination example and states pagination is tested + standalone (still not wired into the client's high-level API); CHANGELOG Unreleased updated.

## Test Plan
- [x] `go test ./pkg/pagination/` (7 tests pass)
- [x] `go build/vet ./...`, `gofmt`, `golangci-lint run` (0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)