### PR TITLE
chore: remove leftover Copilot-bot skip from commit-message check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Architecture Decision Records** and their enforcement (pre-commit/CI ADR checks, `check-adr*` scripts, ADR policy in copilot-instructions).
 - **HTTP service-mode proxy** (`cmd/esi-proxy`) — removed entirely, including the Makefile `build`/`run`/`docker-*` targets and container-image references. This is now a library-only module; use `pkg/client` directly.
 - **`VERSION` file** and `scripts/common/check-version-changelog.sh` — `CHANGELOG.md` plus Git tags (`vX.Y.Z`) are the SemVer source of truth.
-- **GitHub Copilot governance artefacts** — `.github/copilot-instructions.md` and `scripts/common/check-normative.sh` (and its pre-commit step). Commit-message and security checks remain.
+- **GitHub Copilot governance artefacts** — `.github/copilot-instructions.md`, `scripts/common/check-normative.sh` (and its pre-commit step), and the Copilot-bot skip branch in the commit-message check. Commit-message and security checks otherwise remain.
 
 ### Changed
 - README slimmed to a single Quick Start snippet; all other code moved to runnable `examples/`. Docs pruned to `configuration.md` + `troubleshooting.md`.

--- a/scripts/common/check-commit-msg.sh
+++ b/scripts/common/check-commit-msg.sh
@@ -37,16 +37,7 @@ validate_message() {
     
     # Erster Zeile extrahieren
     first_line=$(echo "$msg" | head -n1)
-    
-    # GitHub Copilot Bot Commits überspringen (automatisch generiert)
-    if [ -n "$commit_hash" ]; then
-        commit_author=$(git log -1 --pretty=%an "$commit_hash" 2>/dev/null || echo "")
-        if echo "$commit_author" | grep -qE "copilot.*bot|Copilot.*Agent"; then
-            echo "  ⏩ Übersprungen (Copilot Bot Commit): '$first_line' (Author: $commit_author)"
-            return 0
-        fi
-    fi
-    
+
     # GitHub Merge-Commits überspringen (automatisch generiert)
     if echo "$first_line" | grep -qE "^Merge [0-9a-f]{40} into [0-9a-f]{40}$"; then
         echo "  ⏩ Übersprungen (GitHub Merge-Commit): '$first_line'"


### PR DESCRIPTION
Drops the Copilot-bot skip branch in `scripts/common/check-commit-msg.sh` — the last residual GitHub Copilot governance artifact (the instructions file and `check-normative.sh` were already removed). Documented in the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)