### PR TITLE
docs: drop references to removed metrics/proxy and dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ MIT License - see [LICENSE](LICENSE) file.
 
 ## Contributing
 
-Contributions welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) first.
+Contributions welcome! Conventional Commits sind Pflicht (via `.githooks`), und `make lint test` muss grün sein.
 
 ## Related Projects
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -467,7 +467,6 @@ When reporting issues, include:
 - Error message and full stack trace
 - Configuration (sanitize secrets!)
 - Logs (with debug level enabled)
-- Metrics screenshots if available
 - Steps to reproduce
 
 ## See Also


### PR DESCRIPTION
- README: replace dead `CONTRIBUTING.md` link with the actual contribution rules.
- troubleshooting: remove obsolete "metrics screenshots" bullet — Prometheus metrics were removed; observability is structured logging only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)