### PR TITLE
fix(core): make silent fallbacks fail-loud (#27)

### DIFF
--- a/pkg/cache/http.go
+++ b/pkg/cache/http.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -28,7 +29,12 @@ func ResponseToEntry(resp *http.Response) (*CacheEntry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read response body: %w", err)
 	}
-	_ = resp.Body.Close()
+	if cerr := resp.Body.Close(); cerr != nil {
+		// A close failure after a successful read signals a broken connection/reader;
+		// surface it rather than silently discarding it so the response is not cached
+		// under a false assumption of integrity.
+		return nil, fmt.Errorf("close response body: %w", cerr)
+	}
 
 	// Restore body for caller
 	resp.Body = io.NopCloser(bytes.NewReader(body))
@@ -42,7 +48,12 @@ func ResponseToEntry(resp *http.Response) (*CacheEntry, error) {
 	}
 
 	// Cache-Control hat Vorrang vor Expires (no-store/no-cache → nicht cachen; max-age → TTL).
-	entry.Expires = expiryFromHeaders(resp.Header)
+	// Ein MALFORMED Header ist fail-loud (Fehler); ein ABSENTER Header nutzt legitim DefaultTTL.
+	expires, err := expiryFromHeaders(resp.Header)
+	if err != nil {
+		return nil, err
+	}
+	entry.Expires = expires
 
 	// Parse Last-Modified header
 	if lastModStr := resp.Header.Get("Last-Modified"); lastModStr != "" {
@@ -54,22 +65,34 @@ func ResponseToEntry(resp *http.Response) (*CacheEntry, error) {
 	return entry, nil
 }
 
+// ErrMalformedCacheHeader signals that a cache-relevant header was PRESENT but
+// could not be parsed. A malformed header must fail loud (the caller decides how
+// to proceed) instead of being silently replaced by DefaultTTL, which would break
+// the cache contract without any signal. An ABSENT header is not an error and
+// legitimately uses DefaultTTL (ESI cache compliance).
+var ErrMalformedCacheHeader = errors.New("malformed cache header")
+
 // expiryFromHeaders bestimmt die Ablaufzeit aus Cache-Control (Vorrang) oder Expires.
-func expiryFromHeaders(headers http.Header) time.Time {
+// Ein vorhandener, aber unparsbarer Header (max-age, Expires) ergibt ErrMalformedCacheHeader.
+func expiryFromHeaders(headers http.Header) (time.Time, error) {
 	cc := strings.ToLower(headers.Get("Cache-Control"))
 	if cc != "" {
 		if strings.Contains(cc, "no-store") || strings.Contains(cc, "no-cache") {
-			return time.Now() // TTL 0 → wird nicht gecacht
+			return time.Now(), nil // TTL 0 → wird nicht gecacht
 		}
 		for _, part := range strings.Split(cc, ",") {
 			part = strings.TrimSpace(part)
 			if strings.HasPrefix(part, "max-age=") {
-				if secs, err := strconv.Atoi(strings.TrimPrefix(part, "max-age=")); err == nil {
-					if secs <= 0 {
-						return time.Now()
-					}
-					return time.Now().Add(time.Duration(secs) * time.Second)
+				raw := strings.TrimPrefix(part, "max-age=")
+				secs, err := strconv.Atoi(raw)
+				if err != nil {
+					return time.Time{}, fmt.Errorf("%w: Cache-Control max-age=%q: %v",
+						ErrMalformedCacheHeader, raw, err)
 				}
+				if secs <= 0 {
+					return time.Now(), nil
+				}
+				return time.Now().Add(time.Duration(secs) * time.Second), nil
 			}
 		}
 	}
@@ -77,27 +100,28 @@ func expiryFromHeaders(headers http.Header) time.Time {
 }
 
 // parseExpires parses the Expires header from HTTP headers.
-// Returns the parsed expiration time, or current time + DefaultTTL if parsing fails.
-func parseExpires(headers http.Header) time.Time {
+// Returns current time + DefaultTTL when the header is ABSENT (legitimate ESI default).
+// Returns ErrMalformedCacheHeader when the header is PRESENT but unparsable (fail-loud).
+func parseExpires(headers http.Header) (time.Time, error) {
 	expiresStr := headers.Get("Expires")
 	if expiresStr == "" {
-		// No expires header - use default TTL
-		return time.Now().Add(DefaultTTL)
+		// No expires header - use default TTL (legitimate, ESI cache compliance)
+		return time.Now().Add(DefaultTTL), nil
 	}
 
 	expires, err := http.ParseTime(expiresStr)
 	if err != nil {
-		// Failed to parse expires header - use default TTL
-		return time.Now().Add(DefaultTTL)
+		// Header present but malformed - fail loud instead of silently substituting DefaultTTL
+		return time.Time{}, fmt.Errorf("%w: Expires=%q: %v", ErrMalformedCacheHeader, expiresStr, err)
 	}
 
 	// Validate that TTL is not negative
 	if expires.Before(time.Now()) {
 		// Already expired - use minimal TTL
-		return time.Now()
+		return time.Now(), nil
 	}
 
-	return expires
+	return expires, nil
 }
 
 // ShouldMakeConditionalRequest determines if we should add conditional

--- a/pkg/cache/http_test.go
+++ b/pkg/cache/http_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -98,6 +99,7 @@ func TestParseExpires(t *testing.T) {
 		headers      http.Header
 		wantWithin   time.Duration // Allow some tolerance for timing
 		expectFuture bool
+		wantErr      bool // malformed-present header must fail loud
 	}{
 		{
 			name: "valid expires header",
@@ -118,8 +120,8 @@ func TestParseExpires(t *testing.T) {
 			headers: http.Header{
 				"Expires": []string{"not a valid date"},
 			},
-			wantWithin:   2 * time.Second,
-			expectFuture: true,
+			// Malformed PRESENT Expires header must fail loud, not silently default.
+			wantErr: true,
 		},
 		{
 			name: "expires in the past",
@@ -133,7 +135,20 @@ func TestParseExpires(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parseExpires(tt.headers)
+			got, err := parseExpires(tt.headers)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseExpires() expected error for malformed header, got nil (%v)", got)
+				}
+				if !errors.Is(err, ErrMalformedCacheHeader) {
+					t.Errorf("parseExpires() error = %v, want ErrMalformedCacheHeader", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseExpires() unexpected error: %v", err)
+			}
 
 			if tt.expectFuture && got.Before(now) {
 				t.Errorf("parseExpires() = %v, expected time in the future", got)
@@ -148,8 +163,8 @@ func TestParseExpires(t *testing.T) {
 				}
 			}
 
-			// For default TTL cases
-			if tt.name == "no expires header" || tt.name == "invalid expires header" {
+			// For default TTL cases (absent header)
+			if tt.name == "no expires header" {
 				expected := now.Add(DefaultTTL)
 				diff := got.Sub(expected)
 				if diff < -tt.wantWithin || diff > tt.wantWithin {
@@ -273,6 +288,39 @@ func respWith(headers map[string]string) *http.Response {
 		h.Set(k, v)
 	}
 	return &http.Response{StatusCode: 200, Header: h, Body: io.NopCloser(strings.NewReader("{}"))}
+}
+
+func TestResponseToEntry_MalformedExpiresFailsLoud(t *testing.T) {
+	_, err := ResponseToEntry(respWith(map[string]string{"Expires": "not a valid date"}))
+	if err == nil {
+		t.Fatal("ResponseToEntry must fail loud on a malformed-present Expires header")
+	}
+	if !errors.Is(err, ErrMalformedCacheHeader) {
+		t.Errorf("error = %v, want ErrMalformedCacheHeader", err)
+	}
+}
+
+func TestResponseToEntry_MalformedMaxAgeFailsLoud(t *testing.T) {
+	_, err := ResponseToEntry(respWith(map[string]string{"Cache-Control": "max-age=not-a-number"}))
+	if err == nil {
+		t.Fatal("ResponseToEntry must fail loud on a malformed Cache-Control max-age")
+	}
+	if !errors.Is(err, ErrMalformedCacheHeader) {
+		t.Errorf("error = %v, want ErrMalformedCacheHeader", err)
+	}
+}
+
+func TestResponseToEntry_AbsentExpiresUsesDefaultTTL(t *testing.T) {
+	// An ABSENT Expires header is legitimate and must NOT error (ESI cache compliance).
+	entry, err := ResponseToEntry(respWith(map[string]string{"Content-Type": "application/json"}))
+	if err != nil {
+		t.Fatalf("absent Expires header must not error: %v", err)
+	}
+	ttl := entry.TTL()
+	// Should be close to DefaultTTL.
+	if ttl < DefaultTTL-5*time.Second || ttl > DefaultTTL+5*time.Second {
+		t.Errorf("absent Expires must default to ~DefaultTTL (%v), got %v", DefaultTTL, ttl)
+	}
 }
 
 func TestResponseToEntry_CacheControlNoStore(t *testing.T) {

--- a/pkg/cache/manager.go
+++ b/pkg/cache/manager.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 var (
@@ -20,17 +22,28 @@ var (
 
 // Manager handles caching operations with Redis backend.
 type Manager struct {
-	redis *redis.Client
+	redis  *redis.Client
+	logger zerolog.Logger
 }
 
 // NewManager creates a new cache manager with Redis backend.
+// It logs internal failures (e.g. a stale-entry delete that fails) via the
+// package's zerolog logger; use SetLogger to inject a component-scoped logger.
 func NewManager(redisClient *redis.Client) *Manager {
 	if redisClient == nil {
 		panic("redis client cannot be nil")
 	}
 	return &Manager{
-		redis: redisClient,
+		redis:  redisClient,
+		logger: log.With().Str("component", "esi-cache").Logger(),
 	}
+}
+
+// SetLogger injects a logger so internal warnings (e.g. failed stale-entry
+// deletes) are attributed to the caller's logging context instead of being
+// silently discarded.
+func (m *Manager) SetLogger(logger zerolog.Logger) {
+	m.logger = logger
 }
 
 // Get retrieves a cache entry by key.
@@ -55,8 +68,13 @@ func (m *Manager) Get(ctx context.Context, key CacheKey) (*CacheEntry, error) {
 
 	// Check if expired
 	if entry.IsExpired() {
-		// Delete expired entry
-		_ = m.Delete(ctx, key)
+		// Delete expired entry. A failed delete leaves a stale entry behind, so
+		// log it loudly instead of discarding the error silently. The cache result
+		// is still ErrCacheMiss (the entry is expired regardless).
+		if derr := m.Delete(ctx, key); derr != nil {
+			m.logger.Warn().Err(derr).Str("key", cacheKey).
+				Msg("Failed to delete expired cache entry; stale entry may remain")
+		}
 		return nil, ErrCacheMiss
 	}
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -126,6 +127,7 @@ func New(cfg Config) (*Client, error) {
 
 	// Create cache manager
 	cacheManager := cache.NewManager(cfg.Redis)
+	cacheManager.SetLogger(logger)
 
 	return &Client{
 		httpClient: &http.Client{
@@ -216,7 +218,9 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	// vorhanden ist, einmalig puffern und GetBody setzen.
 	if req.Body != nil && req.GetBody == nil {
 		bodyBytes, berr := io.ReadAll(req.Body)
-		_ = req.Body.Close()
+		if cerr := req.Body.Close(); cerr != nil {
+			c.logger.Warn().Err(cerr).Str("endpoint", endpoint).Msg("Failed to close request body after buffering")
+		}
 		if berr != nil {
 			return nil, fmt.Errorf("buffer request body: %w", berr)
 		}
@@ -228,11 +232,21 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 
 	// Wrap the HTTP request in retry logic
 	retryErr := retryWithBackoff(ctx, func() error {
-		// Body vor jedem Versuch zurücksetzen (sonst nach Versuch 1 verbraucht)
+		// Body vor jedem Versuch zurücksetzen (sonst nach Versuch 1 verbraucht).
+		// Schlägt GetBody fehl, darf NICHT still mit dem konsumierten/stale Body
+		// weitergemacht werden — der Versuch wird mit klarem Fehler abgebrochen.
 		if req.GetBody != nil {
-			if body, gerr := req.GetBody(); gerr == nil {
-				req.Body = body
+			body, gerr := req.GetBody()
+			if gerr != nil {
+				c.logger.Error().Err(gerr).Str("endpoint", endpoint).
+					Msg("Failed to rewind request body for retry")
+				// Body is consumed/broken — retrying is futile. Mark non-retriable so
+				// retryWithBackoff aborts immediately and surfaces the error.
+				errClass = ErrorClassClient
+				lastErr = fmt.Errorf("rewind request body: %w", gerr)
+				return lastErr
 			}
+			req.Body = body
 		}
 
 		// Execute the HTTP request
@@ -283,7 +297,9 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 					ErrorClass: errClass,
 					Message:    resp.Status,
 				}
-				_ = resp.Body.Close() // Close the body before retrying
+				if cerr := resp.Body.Close(); cerr != nil { // Close the body before retrying
+					c.logger.Warn().Err(cerr).Str("endpoint", endpoint).Msg("Failed to close response body before retry")
+				}
 				return lastErr
 			}
 
@@ -301,7 +317,9 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	// Handle retry exhaustion
 	if retryErr != nil {
 		if resp != nil && resp.Body != nil {
-			_ = resp.Body.Close()
+			if cerr := resp.Body.Close(); cerr != nil {
+				c.logger.Warn().Err(cerr).Str("endpoint", endpoint).Msg("Failed to close response body after retry exhaustion")
+			}
 		}
 		return nil, retryErr
 	}
@@ -320,7 +338,9 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		}
 
 		// Return cached response
-		_ = resp.Body.Close()
+		if cerr := resp.Body.Close(); cerr != nil {
+			c.logger.Warn().Err(cerr).Str("endpoint", endpoint).Msg("Failed to close 304 response body")
+		}
 		return c.cacheEntryToResponse(cachedEntry), nil
 	}
 
@@ -328,7 +348,14 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	if resp.StatusCode == http.StatusOK {
 		entry, err := cache.ResponseToEntry(resp)
 		if err != nil {
-			c.logger.Warn().Err(err).Msg("Failed to create cache entry")
+			// Response is still returned to the caller; it is just not cached.
+			// A malformed cache header (fail-loud signal from the cache layer) is
+			// called out explicitly so the uncached outcome is not silent.
+			logEvent := c.logger.Warn().Err(err).Str("endpoint", endpoint)
+			if errors.Is(err, cache.ErrMalformedCacheHeader) {
+				logEvent = logEvent.Bool("malformed_cache_header", true)
+			}
+			logEvent.Msg("Failed to create cache entry; response returned uncached")
 		} else if entry.TTL() > 0 {
 			if err := c.cache.Set(ctx, cacheKey, entry); err != nil {
 				c.logger.Warn().Err(err).Msg("Failed to cache response")
@@ -408,7 +435,11 @@ func (c *Client) FetchPage(ctx context.Context, endpoint string, pageNum int) ([
 	if err != nil {
 		return nil, 0, fmt.Errorf("GET request failed: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			c.logger.Warn().Err(cerr).Str("endpoint", fullEndpoint).Msg("Failed to close response body")
+		}
+	}()
 
 	// Check status
 	if resp.StatusCode != http.StatusOK {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -761,6 +761,13 @@ func TestDo_RetryResendsBody(t *testing.T) {
 	if err := rc.Ping(context.Background()).Err(); err != nil {
 		t.Skipf("Redis not available: %v", err)
 	}
+	// Clear any partial rate-limit state left over from other tests on this DB.
+	// GetState is now fail-loud on a partial state, so a stray errors_remaining
+	// without its siblings would block this request before any retry happens.
+	_ = rc.Del(context.Background(),
+		"esi:rate_limit:errors_remaining",
+		"esi:rate_limit:reset_timestamp",
+		"esi:rate_limit:last_update").Err()
 	cfg := DefaultConfig(rc, "Test/1.0 (t@e.x)")
 	c, err := New(cfg)
 	if err != nil {

--- a/pkg/ratelimit/tracker.go
+++ b/pkg/ratelimit/tracker.go
@@ -3,6 +3,7 @@ package ratelimit
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -11,6 +12,11 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/rs/zerolog"
 )
+
+// ErrIncompleteState signals that the rate limit state in Redis is partial:
+// some keys are present while others are missing. The state cannot be trusted,
+// so callers must treat it as an error rather than assuming a healthy default.
+var ErrIncompleteState = errors.New("incomplete rate limit state in redis")
 
 // decrIfExists dekrementiert errors_remaining nur, wenn der Key existiert
 // (verhindert, dass ein fehlender Key fälschlich auf -1 gesetzt wird).
@@ -43,26 +49,33 @@ func (t *Tracker) RecordError(ctx context.Context) error {
 }
 
 // GetState retrieves the current rate limit state from Redis.
-// Returns a default healthy state if no data exists in Redis.
+// Returns a default healthy state only if ALL state keys are absent (a fresh
+// tracker). Each read is checked independently: if some keys are present but
+// others are missing, or a read fails, the state is incomplete and we surface an
+// error instead of silently assuming a healthy default (e.g. 100 errors remaining)
+// that could mask a real critical state.
 func (t *Tracker) GetState(ctx context.Context) (*RateLimitState, error) {
-	// Fetch all state fields from Redis
+	// Fetch all state fields from Redis, tracking each key's presence independently.
 	errorsRemaining, err := t.redis.Get(ctx, RedisKeyErrorsRemaining).Int()
-	if err != nil && err != redis.Nil {
+	errorsMissing := errors.Is(err, redis.Nil)
+	if err != nil && !errorsMissing {
 		return nil, fmt.Errorf("get errors remaining: %w", err)
 	}
 
 	resetTimestamp, err := t.redis.Get(ctx, RedisKeyResetTimestamp).Int64()
-	if err != nil && err != redis.Nil {
+	resetMissing := errors.Is(err, redis.Nil)
+	if err != nil && !resetMissing {
 		return nil, fmt.Errorf("get reset timestamp: %w", err)
 	}
 
 	lastUpdateStr, err := t.redis.Get(ctx, RedisKeyLastUpdate).Result()
-	if err != nil && err != redis.Nil {
+	lastUpdateMissing := errors.Is(err, redis.Nil)
+	if err != nil && !lastUpdateMissing {
 		return nil, fmt.Errorf("get last update: %w", err)
 	}
 
-	// If no state exists in Redis, return default healthy state
-	if err == redis.Nil {
+	// If NO state exists in Redis (all keys absent), return default healthy state.
+	if errorsMissing && resetMissing && lastUpdateMissing {
 		t.logger.Debug().Msg("No rate limit state in Redis, returning default healthy state")
 		return &RateLimitState{
 			ErrorsRemaining: 100, // Assume healthy until we get real data
@@ -70,6 +83,13 @@ func (t *Tracker) GetState(ctx context.Context) (*RateLimitState, error) {
 			LastUpdate:      time.Now(),
 			IsHealthy:       true,
 		}, nil
+	}
+
+	// Partial state: some keys present, others absent. Assuming a default for the
+	// missing fields could mask a critical error budget, so fail loud.
+	if errorsMissing || resetMissing || lastUpdateMissing {
+		return nil, fmt.Errorf("%w: errors_remaining_present=%t reset_present=%t last_update_present=%t",
+			ErrIncompleteState, !errorsMissing, !resetMissing, !lastUpdateMissing)
 	}
 
 	var lastUpdate time.Time

--- a/pkg/ratelimit/tracker_test.go
+++ b/pkg/ratelimit/tracker_test.go
@@ -2,6 +2,8 @@ package ratelimit
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"net/http"
 	"os"
 	"testing"
@@ -266,6 +268,11 @@ func TestShouldAllowRequest_ThrottleRespectsContext(t *testing.T) {
 	tr := NewTracker(rc, zerolog.Nop())
 	rc.Set(ctx, RedisKeyErrorsRemaining, 10, 0) // warning state (5<=10<20) → würde throtteln
 	rc.Set(ctx, RedisKeyResetTimestamp, time.Now().Add(60*time.Second).Unix(), 0)
+	// Complete state: last_update muss präsent sein, sonst liefert GetState jetzt
+	// ErrIncompleteState (fail-loud) und der Throttle-Pfad würde gar nicht erreicht.
+	if lu, err := json.Marshal(time.Now()); err == nil {
+		rc.Set(ctx, RedisKeyLastUpdate, lu, 0)
+	}
 	cctx, cancel := context.WithCancel(ctx)
 	cancel()
 	start := time.Now()
@@ -275,6 +282,42 @@ func TestShouldAllowRequest_ThrottleRespectsContext(t *testing.T) {
 	}
 	if allowed || err == nil {
 		t.Errorf("erwartet allowed=false,err!=nil; got %v,%v", allowed, err)
+	}
+}
+
+func TestGetState_AllKeysAbsentReturnsDefaultHealthy(t *testing.T) {
+	rc := setupTestRedis(t)
+	defer func() { _ = rc.Close() }()
+	ctx := context.Background()
+	tr := NewTracker(rc, zerolog.Nop())
+
+	st, err := tr.GetState(ctx)
+	if err != nil {
+		t.Fatalf("GetState with no keys must not error: %v", err)
+	}
+	if st.ErrorsRemaining != 100 || !st.IsHealthy {
+		t.Errorf("expected default healthy state (100, healthy), got %d healthy=%v",
+			st.ErrorsRemaining, st.IsHealthy)
+	}
+}
+
+func TestGetState_PartialStateFailsLoud(t *testing.T) {
+	rc := setupTestRedis(t)
+	defer func() { _ = rc.Close() }()
+	ctx := context.Background()
+	tr := NewTracker(rc, zerolog.Nop())
+
+	// Only errors_remaining present (e.g. set to a CRITICAL value); the other keys
+	// are missing. The old code would only check the last read's redis.Nil and could
+	// assume a healthy default, masking this critical state. Now it must fail loud.
+	rc.Set(ctx, RedisKeyErrorsRemaining, 2, 0)
+
+	_, err := tr.GetState(ctx)
+	if err == nil {
+		t.Fatal("GetState must fail loud on partial state, got nil error")
+	}
+	if !errors.Is(err, ErrIncompleteState) {
+		t.Errorf("error = %v, want ErrIncompleteState", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #27. Audit (2026-05-31) found silent fallbacks / swallowed errors that are especially dangerous in a library. This PR makes them **fail-loud** — propagating the error to the caller (or at minimum logging via the library logger) instead of masking it with a silent default.

## Changes per finding

**HIGH**
1. **Retry `GetBody` failure** (`pkg/client/client.go`): a failed body rewind now aborts the attempt with `rewind request body: <err>` (marked non-retriable) instead of silently continuing with a consumed/stale body.
2. **Discarded `Close()` errors** (`pkg/client/client.go`, `pkg/cache/http.go`): response-body close errors are now logged via the lib logger (deferred/idiomatic); the cache-read body close failure is surfaced as an error so a response isn't cached under a false integrity assumption.
3. **Cache delete-on-expiry** (`pkg/cache/manager.go`): `_ = m.Delete(...)` replaced by a logged warning. `Manager` gained a logger (package default + `SetLogger`, wired from the client) — the public `NewManager` signature is unchanged.
4. **Malformed cache headers** (`pkg/cache/http.go`): a **present-but-malformed** `max-age` / `Expires` now returns the new sentinel `ErrMalformedCacheHeader` instead of silently substituting `DefaultTTL`. An **absent** `Expires` still legitimately uses `DefaultTTL` (ESI compliance) — the two cases are now distinguished.
5. **Non-atomic ratelimit read** (`pkg/ratelimit/tracker.go`): `GetState` checks each Redis read independently. All keys absent → default healthy (fresh tracker). A **partial** state (some present, some missing) now returns the new sentinel `ErrIncompleteState` instead of assuming a healthy 100-errors default that could mask a critical budget.

**MED**
6. **200-response caching failure** (`pkg/client/client.go`): kept as log-not-return (the response is still valid and returned to the caller), but the log now names the endpoint, flags `malformed_cache_header`, and states the response was returned uncached — no longer a vague silent warning.

**LOW** (left unchanged, as instructed): `DefaultTTL` on absent `Expires`, and `nil`/`0` returns on `time.Until < 0` in `entry.go` / `state.go`.

## Tests
- `pkg/cache/http_test.go`: malformed `Expires` and malformed `max-age` now assert `ErrMalformedCacheHeader`; absent `Expires` asserts `~DefaultTTL` (no error). Updated `TestParseExpires` for the new `(time.Time, error)` signature.
- `pkg/ratelimit/tracker_test.go`: `TestGetState_PartialStateFailsLoud` (asserts `ErrIncompleteState`) and `TestGetState_AllKeysAbsentReturnsDefaultHealthy`. Existing partial-state test setups updated to write complete state.
- `pkg/client/client_test.go`: `TestDo_RetryResendsBody` now clears stray rate-limit keys (GetState is fail-loud on partial state).

Log-only (not propagated), by design: response-body `Close()` errors and the cache delete-on-expiry warning — least-surprising idiom for deferred cleanup, and a hard test is impractical for these.

## Verification
- `make test` (TZ=UTC, Redis via Docker): all packages **ok**.
- `make lint` (golangci-lint v2.12.2): **0 issues**. `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)