### PR TITLE
feat(ratelimit): adopt ESI group rate limiting (X-Ratelimit-*) alongside legacy error limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **ESI-Gruppen-Rate-Limiting (`X-Ratelimit-*`) — Adoption des neuen CCP-Schemas** (Rollout seit Okt. 2025, Doku: developers.eveonline.com → ESI Rate Limiting). Neuer `ratelimit.GroupTracker`: parst `X-Ratelimit-Group/-Limit/-Remaining` (Format `3600/15m`) aus jeder Antwort, lernt das Endpoint→Gruppe-Mapping (Redis, 24 h TTL) und hält per-Gruppe-State (TTL = Window + 60 s). Gating pro Request-Versuch: bei knappem Token-Budget (< max(5 % des Limits, 10)) 1 s Drossel; nach **429** wird die Gruppe bis `Retry-After` gesperrt — Wartezeiten ≤ 60 s sitzt das Gate inline aus (auch zwischen Retry-Versuchen), längere Sperren schlagen schnell mit `GroupRateLimitedError` fehl.
+- **429-Handling im Client:** 429 wird als `ErrorClassRateLimit` klassifiziert (vorher 4xx-Client → kein Retry) und retried; der Folgeversuch wartet die `Retry-After`-Sperre im Gruppen-Gate ab. 429 belastet das Legacy-Error-Budget **nicht** mehr (kein `RecordError`-Decrement — gehört laut Doku zum neuen Schema).
+
+### Changed
+
+- Doku (README, configuration, troubleshooting) beschreibt jetzt die **Koexistenz beider Systeme**: Gruppen-Token-Buckets auf migrierten Routen (z. B. `market-order: 12000/15m`, `routes: 3600/15m`), Legacy-`X-ESI-Error-Limit-*` (100 Fehler/min, 420) auf noch nicht migrierten Routen (z. B. `universe/*`, `markets/history`). Beide Tracker laufen parallel; Legacy bleibt aktiv und wird auf Legacy-Routen weiter von Headern gefüttert.
+
 ## [0.5.1] - 2026-06-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ Full reference: **[docs/configuration.md](docs/configuration.md)**.
 
 This client strictly follows ESI rules to prevent bans:
 
-✅ **Error Rate Limiting**: Tracks `X-ESI-Error-Limit-Remain` header  
+✅ **Group Rate Limiting**: Tracks `X-Ratelimit-*` headers + honors `Retry-After` on 429  
+✅ **Error Rate Limiting**: Tracks `X-ESI-Error-Limit-Remain` header (legacy routes)  
 ✅ **Cache Respect**: Always honors `expires` header  
 ✅ **Conditional Requests**: Uses `If-None-Match` (ETag)  
 ✅ **Spread Load**: Rate limiting prevents spiky traffic  
@@ -106,9 +107,25 @@ This client strictly follows ESI rules to prevent bans:
 
 ## Rate Limiting
 
-ESI uses **error rate limiting** instead of request rate limiting. The client automatically monitors ESI's error limit headers to prevent IP bans.
+ESI runs **two coexisting rate limit systems** (rollout of the new system started October 2025); the client handles both automatically:
 
-The tracker watches `X-ESI-Error-Limit-Remain` / `X-ESI-Error-Limit-Reset` and operates in three states:
+### 1. Group rate limiting (`X-Ratelimit-*`, migrated routes)
+
+Token buckets per **route group × consumer** (`ApplicationID:CharacterID` for authed, source IP otherwise) with a floating window (`X-Ratelimit-Limit: 3600/15m`). Token costs: 2xx = 2, 3xx = 1 (conditional requests pay off), 4xx = 5, 5xx = 0. Exceeding the bucket returns **429 with `Retry-After`**.
+
+The `GroupTracker` learns each endpoint's group from response headers, shares per-group state via Redis and gates requests:
+
+| Condition | Behavior |
+|-----------|----------|
+| Budget healthy | Normal operation |
+| `Remaining` < max(5 % of limit, 10) | Requests throttled (1s delay) |
+| 429 received | Group blocked until `Retry-After`; waits up to 60s inline, longer blocks fail fast with `GroupRateLimitedError` |
+
+Docs: [ESI rate limiting](https://developers.eveonline.com/docs/services/esi/rate-limiting/).
+
+### 2. Legacy error rate limiting (`X-ESI-Error-Limit-*`, not-yet-migrated routes)
+
+100 non-2xx/3xx per minute, enforced via 420. The tracker watches `X-ESI-Error-Limit-Remain` / `-Reset` and operates in three states:
 
 | State | Errors Remaining | Behavior |
 |-------|-----------------|----------|
@@ -116,7 +133,9 @@ The tracker watches `X-ESI-Error-Limit-Remain` / `X-ESI-Error-Limit-Reset` and o
 | 🟡 **Warning** | 20-49 | Requests throttled (1s delay between calls) |
 | 🔴 **Critical** | < 5 | All requests blocked until reset |
 
-State is shared across all client instances via Redis, ensuring coordinated behavior in multi-instance deployments. **Exceeding the error limit results in a permanent IP ban** — the integrated client handles this for you; for standalone use see **[examples/ratelimit-usage/](examples/ratelimit-usage/)**.
+A state whose 60s window has passed is treated as healthy and all state keys carry TTLs — stale low values cannot throttle indefinitely.
+
+State for both systems is shared across all client instances via Redis, ensuring coordinated behavior in multi-instance deployments. For standalone use see **[examples/ratelimit-usage/](examples/ratelimit-usage/)**.
 
 ## Error Handling & Retry Logic
 
@@ -126,9 +145,9 @@ The client retries transient errors with exponential backoff while never wasting
 
 | Error Class | HTTP Status | Retry? | Description |
 |------------|-------------|--------|-------------|
-| **Client** | 4xx | ❌ No | Client errors (invalid request, not found, etc.) |
+| **Client** | 4xx (except 429) | ❌ No | Client errors (invalid request, not found, etc.) |
 | **Server** | 5xx | ✅ Yes | ESI server errors (temporary issues) |
-| **Rate Limit** | 520 | ✅ Yes | Endpoint-specific rate limit exceeded |
+| **Rate Limit** | 429, 520 | ✅ Yes | Group rate limit (429: retry waits for `Retry-After` via the group gate) / endpoint-specific limit (520) |
 | **Network** | - | ✅ Yes | Connection timeouts, DNS failures, etc. |
 
 ### Retry Strategy

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,7 +111,7 @@ Maximum requests per second to ESI. This is a **soft limit** for your applicatio
 cfg.RateLimit = 10  // Max 10 requests/second
 ```
 
-**Note**: ESI uses error-based rate limiting (not request-based), but this setting helps prevent hammering the API.
+**Note**: ESI enforces two server-side systems — group-based token buckets (`X-Ratelimit-*`, 429) on migrated routes and legacy error-based limiting (`X-ESI-Error-Limit-*`, 420) elsewhere. This client-side setting additionally helps prevent hammering the API.
 
 ### ErrorThreshold
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -98,6 +98,18 @@ for _, endpoint := range endpoints {
 
 ## Rate Limiting
 
+### 429 / "group rate limit gate" errors
+
+**Symptom**: Requests fail with `GroupRateLimitedError` ("esi rate limit group … blocked"), or logs show "ESI group rate limited (429)".
+
+**Cause**: A route group's token bucket (`X-Ratelimit-*`, e.g. `market-order: 12000/15m`) is exhausted. ESI answers 429 with `Retry-After`; the client waits inline for blocks up to 60s and fails fast on longer ones.
+
+**Solution**:
+
+1. Check the group state: `redis-cli get "esi:ratelimit:group:<group>"` (`blocked_until`, `remaining`).
+2. Reduce request volume for that group or spread it over the 15m window; rely on conditional requests (3xx costs 1 token instead of 2).
+3. Long blocks: back off until `Retry-After` has passed — retrying earlier only wastes attempts.
+
 ### Constant rate limit warnings
 
 **Symptom**: Frequent "ESI error limit warning" log messages.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -34,7 +34,7 @@ const (
 	// ErrorClassServer represents 5xx server errors.
 	ErrorClassServer ErrorClass = "server"
 
-	// ErrorClassRateLimit represents 520 rate limit errors.
+	// ErrorClassRateLimit represents rate limit errors (429 group rate limit, 520).
 	ErrorClassRateLimit ErrorClass = "rate_limit"
 
 	// ErrorClassNetwork represents network/timeout errors.
@@ -43,14 +43,15 @@ const (
 
 // Client is the main ESI client.
 type Client struct {
-	httpClient  *http.Client
-	redis       *redis.Client
-	rateLimiter *ratelimit.Tracker
-	cache       *cache.Manager
-	config      Config
-	logger      zerolog.Logger
-	limiter     *rate.Limiter // req/s Token-Bucket (in-memory)
-	sem         chan struct{} // Concurrency-Semaphore (in-memory)
+	httpClient   *http.Client
+	redis        *redis.Client
+	rateLimiter  *ratelimit.Tracker      // Legacy-Error-Limit (X-ESI-Error-Limit-*, nicht migrierte Routen)
+	groupLimiter *ratelimit.GroupTracker // Gruppen-Rate-Limit (X-Ratelimit-*, neue Routen)
+	cache        *cache.Manager
+	config       Config
+	logger       zerolog.Logger
+	limiter      *rate.Limiter // req/s Token-Bucket (in-memory)
+	sem          chan struct{} // Concurrency-Semaphore (in-memory)
 }
 
 // Config holds the client configuration.
@@ -133,13 +134,14 @@ func New(cfg Config) (*Client, error) {
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
-		redis:       cfg.Redis,
-		rateLimiter: rateLimiter,
-		cache:       cacheManager,
-		config:      cfg,
-		logger:      logger,
-		limiter:     rate.NewLimiter(rate.Limit(cfg.RateLimit), cfg.RateLimit),
-		sem:         make(chan struct{}, cfg.MaxConcurrency),
+		redis:        cfg.Redis,
+		rateLimiter:  rateLimiter,
+		groupLimiter: ratelimit.NewGroupTracker(cfg.Redis, logger),
+		cache:        cacheManager,
+		config:       cfg,
+		logger:       logger,
+		limiter:      rate.NewLimiter(rate.Limit(cfg.RateLimit), cfg.RateLimit),
+		sem:          make(chan struct{}, cfg.MaxConcurrency),
 	}, nil
 }
 
@@ -232,6 +234,19 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 
 	// Wrap the HTTP request in retry logic
 	retryErr := retryWithBackoff(ctx, func() error {
+		// Gruppen-Gate (X-Ratelimit-*) pro Versuch: respektiert eine aktive
+		// 429-Sperre (Retry-After) auch ZWISCHEN Retry-Versuchen und bremst,
+		// wenn das Token-Budget der Gruppe zur Neige geht. Lange Sperren
+		// (> maxBlockWait) kommen als GroupRateLimitedError zurück — weitere
+		// Versuche wären zwecklos, deshalb als nicht-retriabel klassifiziert.
+		if gerr := c.groupLimiter.Gate(ctx, endpoint); gerr != nil {
+			c.logger.Warn().Err(gerr).Str("endpoint", endpoint).
+				Msg("Request blocked by group rate limiter")
+			errClass = ErrorClassClient
+			lastErr = fmt.Errorf("group rate limit gate: %w", gerr)
+			return lastErr
+		}
+
 		// Body vor jedem Versuch zurücksetzen (sonst nach Versuch 1 verbraucht).
 		// Schlägt GetBody fehl, darf NICHT still mit dem konsumierten/stale Body
 		// weitergemacht werden — der Versuch wird mit klarem Fehler abgebrochen.
@@ -267,6 +282,12 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 			c.logger.Warn().Err(uerr).Msg("Failed to update rate limit from headers")
 		}
 
+		// Update Gruppen-Rate-Limit (X-Ratelimit-*; migrierte Routen). Lernt
+		// zugleich das Endpoint→Gruppe-Mapping für das Gate.
+		if _, gerr := c.groupLimiter.Update(ctx, endpoint, resp.StatusCode, resp.Header); gerr != nil {
+			c.logger.Warn().Err(gerr).Msg("Failed to update group rate limit state")
+		}
+
 		// Handle 304 Not Modified (not an error, return success)
 		if resp.StatusCode == http.StatusNotModified {
 			return nil
@@ -277,7 +298,10 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 			errClass = c.classifyError(resp, nil)
 			// Optimistischer lokaler Decrement nur, wenn ESI keinen Header lieferte
 			// (sonst ist der Header bereits autoritativ; DECR würde doppelt zählen).
-			if !headerApplied {
+			// 429 gehört zum NEUEN Gruppen-Rate-Limit (oben via groupLimiter.Update
+			// verarbeitet, inkl. Retry-After-Sperre) und zählt laut Doku nicht aufs
+			// Legacy-Error-Budget — kein RecordError.
+			if !headerApplied && resp.StatusCode != http.StatusTooManyRequests {
 				if rerr := c.rateLimiter.RecordError(ctx); rerr != nil {
 					c.logger.Warn().Err(rerr).Msg("Failed to record error in rate limiter")
 				}
@@ -379,6 +403,11 @@ func (c *Client) classifyError(resp *http.Response, err error) ErrorClass {
 	}
 
 	switch {
+	case resp.StatusCode == http.StatusTooManyRequests:
+		// Gruppen-Rate-Limit (X-Ratelimit-*): retriabel — der nächste Versuch
+		// läuft durchs Gruppen-Gate und wartet dort die Retry-After-Sperre ab.
+		c.logger.Debug().Str("class", string(ErrorClassRateLimit)).Msg("Error classified")
+		return ErrorClassRateLimit
 	case resp.StatusCode == 520:
 		c.logger.Debug().Str("class", string(ErrorClassRateLimit)).Msg("Error classified")
 		return ErrorClassRateLimit

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/Sternrassler/eve-esi-client/pkg/cache"
+	"github.com/Sternrassler/eve-esi-client/pkg/ratelimit"
 	"github.com/redis/go-redis/v9"
 	"github.com/rs/zerolog"
 )
@@ -856,5 +857,108 @@ func TestDo_RespectsMaxConcurrency(t *testing.T) {
 	wg.Wait()
 	if got > 2 {
 		t.Errorf("max gleichzeitig in-flight = %d, want <= 2", got)
+	}
+}
+
+// 429-Gruppen-Rate-Limit (X-Ratelimit-*): der erste Versuch wird abgelehnt,
+// der Retry muss die Retry-After-Sperre im Gruppen-Gate abwarten und dann
+// erfolgreich sein. Zudem darf ein 429 das Legacy-Error-Budget NICHT belasten.
+func TestDo_429RetriesAfterRetryAfterAndSucceeds(t *testing.T) {
+	redisClient := setupTestRedis(t)
+	cfg := DefaultConfig(redisClient, "Test/1.0 (t@e.x)")
+	c, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	groupHeaders := func() http.Header {
+		h := make(http.Header)
+		h.Set("X-Ratelimit-Group", "market-order")
+		h.Set("X-Ratelimit-Limit", "12000/15m")
+		h.Set("X-Ratelimit-Used", "2")
+		return h
+	}
+
+	var attempt int
+	c.SetHTTPClient(&http.Client{Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+		attempt++
+		if attempt == 1 {
+			h := groupHeaders()
+			h.Set("X-Ratelimit-Remaining", "0")
+			h.Set("Retry-After", "1")
+			return &http.Response{StatusCode: 429, Status: "429", Header: h, Body: io.NopCloser(strings.NewReader(""))}, nil
+		}
+		h := groupHeaders()
+		h.Set("X-Ratelimit-Remaining", "11000")
+		return &http.Response{StatusCode: 200, Header: h, Body: io.NopCloser(strings.NewReader("[]"))}, nil
+	})})
+
+	// Legacy-Budget seeden, um zu prüfen, dass der 429 es nicht dekrementiert.
+	ctx := context.Background()
+	redisClient.Set(ctx, "esi:rate_limit:errors_remaining", 50, 0)
+	redisClient.Set(ctx, "esi:rate_limit:reset_timestamp", time.Now().Add(55*time.Second).Unix(), 0)
+	if lu, merr := json.Marshal(time.Now()); merr == nil {
+		redisClient.Set(ctx, "esi:rate_limit:last_update", lu, 0)
+	}
+
+	start := time.Now()
+	req, _ := http.NewRequestWithContext(ctx, "GET", "https://esi.evetech.net/v1/markets/10000002/orders/", nil)
+	resp, err := c.Do(req)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if attempt != 2 {
+		t.Errorf("attempts = %d, want 2 (429 then 200)", attempt)
+	}
+	// Retry-After 1s muss abgewartet worden sein (plus Retry-Backoff).
+	if elapsed < 1*time.Second {
+		t.Errorf("expected wait >= Retry-After (1s), took %v", elapsed)
+	}
+	// Legacy-Budget unangetastet (429 gehört zum neuen Schema).
+	if got, _ := redisClient.Get(ctx, "esi:rate_limit:errors_remaining").Int(); got != 50 {
+		t.Errorf("legacy errors_remaining = %d, want 50 (429 must not decrement)", got)
+	}
+}
+
+// Eine lange 429-Sperre (> maxBlockWait des Gruppen-Gates) darf nicht synchron
+// ausgesessen werden: Do bricht schnell mit GroupRateLimitedError ab.
+func TestDo_429LongBlockFailsFast(t *testing.T) {
+	redisClient := setupTestRedis(t)
+	cfg := DefaultConfig(redisClient, "Test/1.0 (t@e.x)")
+	c, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	c.SetHTTPClient(&http.Client{Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+		h := make(http.Header)
+		h.Set("X-Ratelimit-Group", "market-order")
+		h.Set("X-Ratelimit-Limit", "12000/15m")
+		h.Set("X-Ratelimit-Remaining", "0")
+		h.Set("Retry-After", "900")
+		return &http.Response{StatusCode: 429, Status: "429", Header: h, Body: io.NopCloser(strings.NewReader(""))}, nil
+	})})
+
+	ctx := context.Background()
+	req, _ := http.NewRequestWithContext(ctx, "GET", "https://esi.evetech.net/v1/markets/10000002/orders/", nil)
+	start := time.Now()
+	_, err = c.Do(req)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected error for long 429 block")
+	}
+	var rlErr *ratelimit.GroupRateLimitedError
+	if !errors.As(err, &rlErr) {
+		t.Fatalf("expected GroupRateLimitedError in chain, got %v", err)
+	}
+	// Erster Versuch (429) + abgebrochener zweiter Versuch — aber kein 900s-Sitzen.
+	if elapsed > 30*time.Second {
+		t.Errorf("must fail fast, took %v", elapsed)
 	}
 }

--- a/pkg/ratelimit/groups.go
+++ b/pkg/ratelimit/groups.go
@@ -1,0 +1,255 @@
+package ratelimit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
+)
+
+// ESI group rate limiting (X-Ratelimit-* headers, rollout ab Oktober 2025).
+//
+// Jede Route-Gruppe × Consumer (ApplicationID:CharacterID bzw. SourceIP) hat
+// einen Token-Bucket mit Floating Window (Header-Format "3600/15m"). Kosten:
+// 2xx = 2 Tokens, 3xx = 1, 4xx = 5, 5xx = 0. Überschreitung ⇒ 429 mit
+// Retry-After (Sekunden). Die Gruppen-Zugehörigkeit eines Endpoints steht nur
+// in der Response (X-Ratelimit-Group) — der Tracker lernt das Mapping
+// Endpoint→Gruppe aus beobachteten Antworten.
+//
+// Quelle: https://developers.eveonline.com/docs/services/esi/rate-limiting/
+// Koexistenz: Routen ohne neues Rate Limiting tragen weiterhin die Legacy-
+// X-ESI-Error-Limit-Header (siehe Tracker).
+
+// Redis keys for group rate limit state.
+const (
+	// RedisKeyGroupPrefix + <group> → JSON GroupState, TTL = Window + Puffer.
+	RedisKeyGroupPrefix = "esi:ratelimit:group:"
+	// RedisKeyEndpointPrefix + <endpoint> → Gruppenname (gelerntes Mapping).
+	RedisKeyEndpointPrefix = "esi:ratelimit:endpoint:"
+)
+
+const (
+	// endpointMappingTTL begrenzt das gelernte Endpoint→Gruppe-Mapping.
+	endpointMappingTTL = 24 * time.Hour
+
+	// groupStateTTLBuffer wird auf die Window-Dauer aufgeschlagen, damit der
+	// State das Floating Window sicher überdauert, aber nicht ewig lebt.
+	groupStateTTLBuffer = 60 * time.Second
+
+	// maxBlockWait ist die längste Wartezeit, die Gate für eine 429-Sperre
+	// synchron aussitzt; längere Sperren werden als Fehler gemeldet.
+	maxBlockWait = 60 * time.Second
+
+	// groupThrottleSleep bremst Requests, wenn das Token-Budget einer Gruppe
+	// zur Neige geht (Doku: "slow down as Remaining approaches zero").
+	groupThrottleSleep = 1 * time.Second
+
+	// fallbackRetryAfter greift, wenn eine 429-Antwort keinen (parsebaren)
+	// Retry-After-Header trägt.
+	fallbackRetryAfter = 60 * time.Second
+)
+
+// GroupRateLimitedError signalisiert eine 429-Sperre, die länger als
+// maxBlockWait andauert — der Aufrufer soll nicht synchron warten.
+type GroupRateLimitedError struct {
+	Group      string
+	RetryAfter time.Duration
+}
+
+func (e *GroupRateLimitedError) Error() string {
+	return fmt.Sprintf("esi rate limit group %q blocked for %s (429 Retry-After)", e.Group, e.RetryAfter.Round(time.Second))
+}
+
+// GroupState ist der in Redis geteilte Zustand einer Rate-Limit-Gruppe.
+type GroupState struct {
+	Group         string    `json:"group"`
+	Limit         int       `json:"limit"`
+	WindowSeconds int       `json:"window_seconds"`
+	Remaining     int       `json:"remaining"`
+	UpdatedAt     time.Time `json:"updated_at"`
+	// BlockedUntil ist gesetzt, wenn die letzte Antwort dieser Gruppe ein 429
+	// war (jetzt + Retry-After). Eine spätere Nicht-429-Antwort löscht die
+	// Sperre durch Überschreiben des States.
+	BlockedUntil time.Time `json:"blocked_until,omitzero"`
+}
+
+// throttleThreshold liefert die Remaining-Schwelle, unter der Requests dieser
+// Gruppe gebremst werden: 5 % des Limits, mindestens 10 Tokens.
+func (s *GroupState) throttleThreshold() int {
+	return max(s.Limit/20, 10)
+}
+
+// GroupTracker verfolgt die ESI-Gruppen-Rate-Limits (X-Ratelimit-*) und gated
+// Requests pro Gruppe. Zustand liegt in Redis und ist damit über alle
+// Client-Instanzen geteilt — wie beim Legacy-Tracker.
+type GroupTracker struct {
+	redis  *redis.Client
+	logger zerolog.Logger
+}
+
+// NewGroupTracker creates a new group rate limit tracker.
+func NewGroupTracker(redisClient *redis.Client, logger zerolog.Logger) *GroupTracker {
+	return &GroupTracker{
+		redis:  redisClient,
+		logger: logger,
+	}
+}
+
+// parseRateLimitHeader zerlegt das X-Ratelimit-Limit-Format "3600/15m" in
+// Token-Limit und Window-Dauer.
+func parseRateLimitHeader(value string) (int, time.Duration, error) {
+	parts := strings.SplitN(value, "/", 2)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("malformed X-Ratelimit-Limit %q (want <tokens>/<window>)", value)
+	}
+	limit, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse X-Ratelimit-Limit tokens %q: %w", parts[0], err)
+	}
+	window, err := time.ParseDuration(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse X-Ratelimit-Limit window %q: %w", parts[1], err)
+	}
+	if limit <= 0 || window <= 0 {
+		return 0, 0, fmt.Errorf("non-positive X-Ratelimit-Limit %q", value)
+	}
+	return limit, window, nil
+}
+
+// Update wertet die X-Ratelimit-Header einer Antwort aus und aktualisiert den
+// Gruppen-State plus das gelernte Endpoint→Gruppe-Mapping. Liefert (false, nil),
+// wenn die Antwort keine Gruppen-Header trägt (Legacy-Route), (true, nil) bei
+// erfolgreichem Update.
+func (t *GroupTracker) Update(ctx context.Context, endpoint string, statusCode int, headers http.Header) (bool, error) {
+	group := headers.Get("X-Ratelimit-Group")
+	if group == "" {
+		return false, nil
+	}
+
+	limit, window, err := parseRateLimitHeader(headers.Get("X-Ratelimit-Limit"))
+	if err != nil {
+		return false, err
+	}
+
+	remaining, err := strconv.Atoi(strings.TrimSpace(headers.Get("X-Ratelimit-Remaining")))
+	if err != nil {
+		return false, fmt.Errorf("parse X-Ratelimit-Remaining: %w", err)
+	}
+
+	now := time.Now()
+	state := &GroupState{
+		Group:         group,
+		Limit:         limit,
+		WindowSeconds: int(window.Seconds()),
+		Remaining:     remaining,
+		UpdatedAt:     now,
+	}
+
+	if statusCode == http.StatusTooManyRequests {
+		retryAfter := fallbackRetryAfter
+		if raw := headers.Get("Retry-After"); raw != "" {
+			if seconds, perr := strconv.Atoi(strings.TrimSpace(raw)); perr == nil && seconds >= 0 {
+				retryAfter = time.Duration(seconds) * time.Second
+			}
+		}
+		state.BlockedUntil = now.Add(retryAfter)
+	}
+
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return false, fmt.Errorf("marshal group state: %w", err)
+	}
+
+	pipe := t.redis.Pipeline()
+	pipe.Set(ctx, RedisKeyGroupPrefix+group, payload, window+groupStateTTLBuffer)
+	pipe.Set(ctx, RedisKeyEndpointPrefix+endpoint, group, endpointMappingTTL)
+	if _, err := pipe.Exec(ctx); err != nil {
+		return false, fmt.Errorf("store group rate limit state: %w", err)
+	}
+
+	switch {
+	case !state.BlockedUntil.IsZero():
+		t.logger.Warn().
+			Str("group", group).
+			Time("blocked_until", state.BlockedUntil).
+			Msg("ESI group rate limited (429) - blocking group")
+	case remaining < state.throttleThreshold():
+		t.logger.Warn().
+			Str("group", group).
+			Int("remaining", remaining).
+			Int("limit", limit).
+			Msg("ESI group token budget low - requests will be throttled")
+	default:
+		t.logger.Debug().
+			Str("group", group).
+			Int("remaining", remaining).
+			Int("limit", limit).
+			Msg("ESI group rate limit state updated")
+	}
+
+	return true, nil
+}
+
+// Gate bremst bzw. blockiert einen Request anhand des Gruppen-States seines
+// Endpoints. Unbekannte Endpoints/Gruppen (kein gelerntes Mapping, abgelaufener
+// State) passieren ungebremst. Bei einer aktiven 429-Sperre wartet Gate bis zu
+// maxBlockWait; längere Sperren liefern GroupRateLimitedError.
+func (t *GroupTracker) Gate(ctx context.Context, endpoint string) error {
+	group, err := t.redis.Get(ctx, RedisKeyEndpointPrefix+endpoint).Result()
+	if errors.Is(err, redis.Nil) {
+		return nil // Endpoint(-Gruppe) noch nicht beobachtet
+	}
+	if err != nil {
+		return fmt.Errorf("get endpoint group mapping: %w", err)
+	}
+
+	payload, err := t.redis.Get(ctx, RedisKeyGroupPrefix+group).Result()
+	if errors.Is(err, redis.Nil) {
+		return nil // State abgelaufen ⇒ Window vorbei ⇒ Budget wieder voll
+	}
+	if err != nil {
+		return fmt.Errorf("get group rate limit state: %w", err)
+	}
+
+	var state GroupState
+	if err := json.Unmarshal([]byte(payload), &state); err != nil {
+		return fmt.Errorf("parse group rate limit state: %w", err)
+	}
+
+	if wait := time.Until(state.BlockedUntil); wait > 0 {
+		if wait > maxBlockWait {
+			return &GroupRateLimitedError{Group: group, RetryAfter: wait}
+		}
+		t.logger.Warn().
+			Str("group", group).
+			Dur("wait", wait).
+			Msg("ESI group blocked (429) - waiting for Retry-After")
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(wait):
+		}
+		return nil
+	}
+
+	if state.Remaining < state.throttleThreshold() {
+		t.logger.Warn().
+			Str("group", group).
+			Int("remaining", state.Remaining).
+			Msg("ESI group token budget low - throttling request")
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(groupThrottleSleep):
+		}
+	}
+
+	return nil
+}

--- a/pkg/ratelimit/groups_test.go
+++ b/pkg/ratelimit/groups_test.go
@@ -1,0 +1,231 @@
+package ratelimit
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+func groupHeaders(group, limit, remaining string) http.Header {
+	h := http.Header{}
+	h.Set("X-Ratelimit-Group", group)
+	h.Set("X-Ratelimit-Limit", limit)
+	h.Set("X-Ratelimit-Remaining", remaining)
+	h.Set("X-Ratelimit-Used", "2")
+	return h
+}
+
+func TestParseRateLimitHeader(t *testing.T) {
+	tests := []struct {
+		in        string
+		limit     int
+		window    time.Duration
+		shouldErr bool
+	}{
+		{"3600/15m", 3600, 15 * time.Minute, false},
+		{"150/15m", 150, 15 * time.Minute, false},
+		{"12000/15m", 12000, 15 * time.Minute, false},
+		{"100/1h", 100, time.Hour, false},
+		{"garbage", 0, 0, true},
+		{"/15m", 0, 0, true},
+		{"100/", 0, 0, true},
+		{"0/15m", 0, 0, true},
+	}
+	for _, tt := range tests {
+		limit, window, err := parseRateLimitHeader(tt.in)
+		if tt.shouldErr {
+			if err == nil {
+				t.Errorf("parse(%q): expected error", tt.in)
+			}
+			continue
+		}
+		if err != nil || limit != tt.limit || window != tt.window {
+			t.Errorf("parse(%q) = (%d, %v, %v), want (%d, %v, nil)", tt.in, limit, window, err, tt.limit, tt.window)
+		}
+	}
+}
+
+func TestGroupUpdate_StoresStateAndMapping(t *testing.T) {
+	rc := setupTestRedis(t)
+	defer func() { _ = rc.Close() }()
+	ctx := context.Background()
+	gt := NewGroupTracker(rc, zerolog.Nop())
+
+	applied, err := gt.Update(ctx, "/v1/markets/10000002/orders/", 200, groupHeaders("market-order", "12000/15m", "11991"))
+	if err != nil || !applied {
+		t.Fatalf("Update: applied=%v err=%v", applied, err)
+	}
+
+	group, err := rc.Get(ctx, RedisKeyEndpointPrefix+"/v1/markets/10000002/orders/").Result()
+	if err != nil || group != "market-order" {
+		t.Errorf("endpoint mapping = (%q, %v), want market-order", group, err)
+	}
+	for _, key := range []string{RedisKeyGroupPrefix + "market-order", RedisKeyEndpointPrefix + "/v1/markets/10000002/orders/"} {
+		if ttl := rc.TTL(ctx, key).Val(); ttl <= 0 {
+			t.Errorf("key %s must have TTL, got %v", key, ttl)
+		}
+	}
+}
+
+func TestGroupUpdate_NoHeadersIsLegacyRoute(t *testing.T) {
+	rc := setupTestRedis(t)
+	defer func() { _ = rc.Close() }()
+	ctx := context.Background()
+	gt := NewGroupTracker(rc, zerolog.Nop())
+
+	applied, err := gt.Update(ctx, "/v3/universe/types/34/", 200, http.Header{})
+	if err != nil || applied {
+		t.Fatalf("Update without group headers must be (false, nil), got (%v, %v)", applied, err)
+	}
+	if n := len(rc.Keys(ctx, RedisKeyGroupPrefix+"*").Val()); n != 0 {
+		t.Errorf("no group state must be stored, found %d keys", n)
+	}
+}
+
+func TestGroupGate_UnknownEndpointAllowsImmediately(t *testing.T) {
+	rc := setupTestRedis(t)
+	defer func() { _ = rc.Close() }()
+	gt := NewGroupTracker(rc, zerolog.Nop())
+
+	start := time.Now()
+	if err := gt.Gate(context.Background(), "/v1/never/seen/"); err != nil {
+		t.Fatalf("Gate: %v", err)
+	}
+	if time.Since(start) > 200*time.Millisecond {
+		t.Errorf("unknown endpoint must not wait, took %v", time.Since(start))
+	}
+}
+
+func TestGroupGate_HealthyBudgetAllowsImmediately(t *testing.T) {
+	rc := setupTestRedis(t)
+	defer func() { _ = rc.Close() }()
+	ctx := context.Background()
+	gt := NewGroupTracker(rc, zerolog.Nop())
+
+	if _, err := gt.Update(ctx, "/v1/route/a/b/", 200, groupHeaders("routes", "3600/15m", "3000")); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	start := time.Now()
+	if err := gt.Gate(ctx, "/v1/route/a/b/"); err != nil {
+		t.Fatalf("Gate: %v", err)
+	}
+	if time.Since(start) > 200*time.Millisecond {
+		t.Errorf("healthy budget must not wait, took %v", time.Since(start))
+	}
+}
+
+func TestGroupGate_LowBudgetThrottles(t *testing.T) {
+	rc := setupTestRedis(t)
+	defer func() { _ = rc.Close() }()
+	ctx := context.Background()
+	gt := NewGroupTracker(rc, zerolog.Nop())
+
+	// 150er-Limit → Schwelle max(7,10)=10; Remaining 5 < 10 ⇒ Throttle-Sleep.
+	if _, err := gt.Update(ctx, "/v1/status/", 200, groupHeaders("status", "150/15m", "5")); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	start := time.Now()
+	if err := gt.Gate(ctx, "/v1/status/"); err != nil {
+		t.Fatalf("Gate: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < 900*time.Millisecond || elapsed > 2*time.Second {
+		t.Errorf("low budget must throttle ~1s, took %v", elapsed)
+	}
+}
+
+func TestGroupGate_429BlocksUntilRetryAfter(t *testing.T) {
+	rc := setupTestRedis(t)
+	defer func() { _ = rc.Close() }()
+	ctx := context.Background()
+	gt := NewGroupTracker(rc, zerolog.Nop())
+
+	h := groupHeaders("market-order", "12000/15m", "0")
+	h.Set("Retry-After", "1")
+	if _, err := gt.Update(ctx, "/v1/markets/10000002/orders/", 429, h); err != nil {
+		t.Fatalf("Update(429): %v", err)
+	}
+
+	start := time.Now()
+	if err := gt.Gate(ctx, "/v1/markets/10000002/orders/"); err != nil {
+		t.Fatalf("Gate: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < 700*time.Millisecond || elapsed > 2*time.Second {
+		t.Errorf("blocked group must wait ~Retry-After (1s), took %v", elapsed)
+	}
+
+	// Eine spätere Erfolgsantwort hebt die Sperre auf.
+	if _, err := gt.Update(ctx, "/v1/markets/10000002/orders/", 200, groupHeaders("market-order", "12000/15m", "11000")); err != nil {
+		t.Fatalf("Update(200): %v", err)
+	}
+	start = time.Now()
+	if err := gt.Gate(ctx, "/v1/markets/10000002/orders/"); err != nil {
+		t.Fatalf("Gate after unblock: %v", err)
+	}
+	if time.Since(start) > 200*time.Millisecond {
+		t.Errorf("unblocked group must not wait, took %v", time.Since(start))
+	}
+}
+
+func TestGroupGate_LongBlockFailsFast(t *testing.T) {
+	rc := setupTestRedis(t)
+	defer func() { _ = rc.Close() }()
+	ctx := context.Background()
+	gt := NewGroupTracker(rc, zerolog.Nop())
+
+	h := groupHeaders("market-order", "12000/15m", "0")
+	h.Set("Retry-After", "900") // 15 min > maxBlockWait
+	if _, err := gt.Update(ctx, "/v1/markets/10000002/orders/", 429, h); err != nil {
+		t.Fatalf("Update(429): %v", err)
+	}
+
+	start := time.Now()
+	err := gt.Gate(ctx, "/v1/markets/10000002/orders/")
+	if time.Since(start) > 200*time.Millisecond {
+		t.Errorf("long block must fail fast, took %v", time.Since(start))
+	}
+	var rlErr *GroupRateLimitedError
+	if err == nil || !asGroupRateLimited(err, &rlErr) {
+		t.Fatalf("expected GroupRateLimitedError, got %v", err)
+	}
+	if rlErr.Group != "market-order" || rlErr.RetryAfter < 10*time.Minute {
+		t.Errorf("unexpected error contents: %+v", rlErr)
+	}
+}
+
+func asGroupRateLimited(err error, target **GroupRateLimitedError) bool {
+	for err != nil {
+		if e, ok := err.(*GroupRateLimitedError); ok {
+			*target = e
+			return true
+		}
+		u, ok := err.(interface{ Unwrap() error })
+		if !ok {
+			return false
+		}
+		err = u.Unwrap()
+	}
+	return false
+}
+
+func TestGroupGate_ContextCancelDuringThrottle(t *testing.T) {
+	rc := setupTestRedis(t)
+	defer func() { _ = rc.Close() }()
+	ctx := context.Background()
+	gt := NewGroupTracker(rc, zerolog.Nop())
+
+	if _, err := gt.Update(ctx, "/v1/status/", 200, groupHeaders("status", "150/15m", "5")); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	cctx, cancel := context.WithCancel(ctx)
+	cancel()
+	start := time.Now()
+	if err := gt.Gate(cctx, "/v1/status/"); err == nil {
+		t.Error("cancelled context must abort throttle with error")
+	}
+	if time.Since(start) > 200*time.Millisecond {
+		t.Errorf("cancelled context must not sleep, took %v", time.Since(start))
+	}
+}

--- a/pkg/ratelimit/tracker_test.go
+++ b/pkg/ratelimit/tracker_test.go
@@ -229,6 +229,9 @@ func setupTestRedis(t *testing.T) *redis.Client {
 		t.Skipf("Redis not available: %v", err)
 	}
 	c.Del(ctx, RedisKeyErrorsRemaining, RedisKeyResetTimestamp, RedisKeyLastUpdate)
+	if keys, err := c.Keys(ctx, "esi:ratelimit:*").Result(); err == nil && len(keys) > 0 {
+		c.Del(ctx, keys...)
+	}
 	return c
 }
 


### PR DESCRIPTION
## Was

Adoption des neuen CCP-Rate-Limit-Schemas (Rollout seit Okt. 2025) — vorab gegen die aktuelle Doku studiert ([ESI Rate Limiting](https://developers.eveonline.com/docs/services/esi/rate-limiting/), [Intro-Blog](https://developers.eveonline.com/blog/hold-your-horses-introducing-rate-limiting-to-esi)) und empirisch verifiziert (Header-Verhalten auf `/v1` + `/latest`, Markt vs. Universe vs. Routes).

**Doku-Essenz:** Token-Bucket pro Gruppe × Consumer, Floating Window (`X-Ratelimit-Limit: 3600/15m`), Kosten 2xx=2 / 3xx=1 / 4xx=5 / 5xx=0, Überschreitung → **429 + Retry-After**. Gruppen-Zugehörigkeit steht nur in der Response. **Koexistenz:** nicht migrierte Routen (`universe/*`, `markets/history`, …) tragen weiter die Legacy-`X-ESI-Error-Limit-*`-Header (420-System).

## Implementierung

- **Neuer `ratelimit.GroupTracker`** (`pkg/ratelimit/groups.go`): parst die `X-Ratelimit-*`-Header jeder Antwort, lernt Endpoint→Gruppe (Redis, 24 h TTL), hält per-Gruppe-State mit TTL = Window + 60 s (kein Ewig-State — Lektion aus v0.5.1).
- **Gate pro Request-Versuch** (im Retry-Closure): Budget < max(5 % des Limits, 10) → 1 s Drossel; aktive 429-Sperre → wartet `Retry-After` inline (≤ 60 s, auch zwischen Retries), längere Sperren → schneller Abbruch mit `GroupRateLimitedError`.
- **429-Klassifizierung:** `ErrorClassRateLimit` (vorher: 4xx-Client → kein Retry); kein `RecordError`-Decrement aufs Legacy-Budget (429 gehört zum neuen Schema).
- **Legacy-Tracker bleibt aktiv** — wird auf nicht migrierten Routen weiter von Headern gefüttert; beide Systeme laufen parallel.
- Doku (README/configuration/troubleshooting) auf die Zwei-System-Realität gezogen.

## Tests (TDD)

- 9 neue `GroupTracker`-Tests: Header-Parsing (`3600/15m`-Formate inkl. Fehlerfälle), State+Mapping+TTLs, Legacy-Route = No-Op, Gate-Verhalten (unbekannt/gesund sofort, Low-Budget ~1 s, 429-Sperre bis Retry-After, Entsperrung durch Folge-Antwort, Langsperre fail-fast, ctx-cancel).
- 2 Client-Level-Tests: 429 → Retry wartet Retry-After → 200 (und Legacy-Budget bleibt unangetastet); lange 429-Sperre bricht schnell ab.
- `TZ=UTC go test ./...` komplett grün, golangci-lint 0 Issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
