### PR TITLE
feat(cache): Fresh-Serve — frische Cache-Einträge ohne Netzwerk-Roundtrip (GET-only Caching)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Fresh-Serve: frische Cache-Einträge werden ohne Netzwerk-Roundtrip serviert.** `RespectExpires` versprach dieses Verhalten („MUST be true for ESI compliance"), wurde aber nur validiert — tatsächlich revalidierte der Client **jeden** frischen Treffer per Conditional Request (304-Roundtrip: Latenz, 1 Token im Gruppen-Rate-Limit, Gate-Pass pro Lookup; warme Berechnungen machten dadurch hunderte unnötige Requests). Jetzt: GET-Cache-Lookup **vor** allen Gates; ein frischer Eintrag (Expires in der Zukunft = CCPs Freshness-Vertrag) wird direkt aus Redis beantwortet — inklusive aller Header (`X-Pages` für Pagination bleibt erhalten). Abgelaufene Einträge werden wie bisher voll neu geladen (kein Verhaltensverlust: Redis-TTL räumte sie ohnehin ab, ein 304-Pfad für abgelaufene Einträge existierte faktisch nie).
+- **Caching strikt GET-only.** Vorher floss jeder 200 in den Cache und jeder Treffer in die Conditional-Header (cross-method harmlos, aber falsch) — mit Fresh-Serve wäre das fatal (POST aus dem Cache „beantwortet"). Cache-Lookup **und** Cache-Write sind jetzt auf GET begrenzt.
+- **Conditional Requests entfernt; unerwartete 304 sind fail-loud.** Da der Client keine `If-None-Match`-Header mehr sendet, ist ein 304 von ESI eine Protokollverletzung und liefert einen klaren Fehler statt eines leeren Responses. ETags werden weiter mitgespeichert — Grundlage für eine mögliche künftige Stale-with-ETag-Revalidierung (Eintrag über Expires hinaus aufbewahren → 304 statt Voll-Fetch).
+
 ## [0.6.0] - 2026-06-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -100,8 +100,7 @@ This client strictly follows ESI rules to prevent bans:
 
 ✅ **Group Rate Limiting**: Tracks `X-Ratelimit-*` headers + honors `Retry-After` on 429  
 ✅ **Error Rate Limiting**: Tracks `X-ESI-Error-Limit-Remain` header (legacy routes)  
-✅ **Cache Respect**: Always honors `expires` header  
-✅ **Conditional Requests**: Uses `If-None-Match` (ETag)  
+✅ **Cache Respect**: Fresh entries (within `Expires`) are served from cache — no re-request, no token cost  
 ✅ **Spread Load**: Rate limiting prevents spiky traffic  
 ✅ **User-Agent**: Required with contact info  
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,31 +172,32 @@ ESI compliance requires respecting cache expiration headers. Setting to `false` 
 
 ### Cache Behavior
 
-The client implements a two-tier caching strategy:
+The client caches GET responses in Redis and serves them as long as they are fresh:
 
-1. **Redis Cache** (primary)
-   - Stores full response body
-   - Respects ESI `Expires` header
+1. **Redis Cache**
+   - Stores full response body + headers (incl. ETag)
+   - Respects ESI `Expires` header (entry TTL = freshness window)
    - Shared across all client instances
 
-2. **Conditional Requests**
-   - Uses `If-None-Match` header with ETag
-   - Receives `304 Not Modified` when cache is valid
-   - Updates TTL from new `Expires` header
+2. **Fresh-Serve**
+   - A fresh entry (within `Expires`) is returned **without any network request** — no latency, no rate-limit token cost
+   - Expired entries are evicted; the next request fetches fresh data
 
 **Cache Flow:**
 
 ```
-Request → Check Redis Cache
+GET Request → Check Redis Cache
   ↓
-Cache Hit?
-  ↓ Yes                    ↓ No
-Make conditional request   Make normal request
-  ↓                        ↓
-304 Not Modified?          Store in cache
-  ↓ Yes      ↓ No           ↓
-Return cached | Update cache | Return response
+Fresh entry?
+  ↓ Yes                       ↓ No (missing/expired)
+Serve from cache (no HTTP)    Make ESI request
+                              ↓
+                              Store in cache (TTL = Expires)
+                              ↓
+                              Return response
 ```
+
+*Hinweis:* Stale-with-ETag-Revalidierung (abgelaufene Einträge per `If-None-Match` → `304` auffrischen statt voll zu laden) ist eine mögliche künftige Erweiterung; ETags werden dafür bereits mitgespeichert.
 
 ## Retry Behavior
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -107,7 +107,7 @@ for _, endpoint := range endpoints {
 **Solution**:
 
 1. Check the group state: `redis-cli get "esi:ratelimit:group:<group>"` (`blocked_until`, `remaining`).
-2. Reduce request volume for that group or spread it over the 15m window; rely on conditional requests (3xx costs 1 token instead of 2).
+2. Reduce request volume for that group or spread it over the 15m window; fresh cache hits cost no tokens at all — recompute within the `Expires` window where possible.
 3. Long blocks: back off until `Retry-After` has passed — retrying earlier only wastes attempts.
 
 ### Constant rate limit warnings

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -199,22 +199,13 @@ for _, endpoint := range endpoints {
    {"endpoint":"/v1/status/","ttl":299.5,"message":"Cached response"}
    ```
 
-### 304 Not Modified but still downloading data
+### Unexpected 304 errors
 
-**Symptom**: Seeing 304 responses but bandwidth usage is high.
+**Symptom**: Requests fail with `unexpected 304 from ESI without conditional request`.
 
-**Cause**: This is normal - 304 means server validated, but client must have cached data.
+**Cause**: The client serves fresh cache entries directly and sends no conditional requests — a 304 from ESI is therefore a protocol violation (or a misbehaving proxy) and is surfaced fail-loud instead of returning empty data.
 
-**How it works**:
-```
-1. Client has cached data with ETag "abc123"
-2. Client sends request with If-None-Match: "abc123"
-3. Server checks, data unchanged
-4. Server returns 304 Not Modified (small response, ~200 bytes)
-5. Client returns cached data to user (from Redis)
-```
-
-**Bandwidth saved**: Instead of 100KB response, client receives 200 byte response.
+**Solution**: Check for intermediaries that inject `If-None-Match`/`If-Modified-Since` headers into outgoing requests.
 
 ### Cache not expiring
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -151,6 +151,47 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
 	endpoint := req.URL.Path
 
+	// Caching gilt ausschließlich für GET: nur dort sind Antworten per
+	// Expires/ETag cachebar; POST/PUT/DELETE dürfen weder aus dem Cache
+	// bedient werden noch ihn befüllen.
+	cacheable := req.Method == http.MethodGet || req.Method == ""
+
+	// Step 1: Check Cache — VOR allen Gates: ein frischer Treffer kostet
+	// keinen ESI-Request und soll weder Limiter/Semaphore belegen noch
+	// Rate-Limit-Drosseln durchlaufen.
+	cacheKey := cache.CacheKey{
+		Endpoint:    endpoint,
+		QueryParams: req.URL.Query(),
+	}
+	// Authentifizierte Requests: Hash des Authorization-Headers in den Key (kein Roh-Token).
+	if authHeader := req.Header.Get("Authorization"); authHeader != "" {
+		sum := sha256.Sum256([]byte(authHeader))
+		cacheKey.Auth = hex.EncodeToString(sum[:])[:16]
+	}
+
+	var cachedEntry *cache.CacheEntry
+	if cacheable {
+		entry, cerr := c.cache.Get(ctx, cacheKey)
+		if cerr != nil && cerr != cache.ErrCacheMiss {
+			c.logger.Warn().Err(cerr).Str("endpoint", endpoint).Msg("Cache get error")
+		}
+		cachedEntry = entry
+	}
+
+	// Fresh-Serve: cache.Get liefert ausschließlich un-abgelaufene Einträge
+	// (Expires in der Zukunft = CCPs Freshness-Vertrag) — sie werden OHNE
+	// Netzwerk-Roundtrip serviert. Das ist das Verhalten, das RespectExpires
+	// verspricht; vorher revalidierte der Client jeden frischen Treffer per
+	// Conditional Request (304-Roundtrip: Latenz + 1 Token Gruppen-Rate-Limit
+	// + Gate-Pass pro Lookup).
+	if cachedEntry != nil {
+		c.logger.Debug().
+			Str("endpoint", endpoint).
+			Dur("ttl", cachedEntry.TTL()).
+			Msg("Fresh cache hit - serving without revalidation")
+		return c.cacheEntryToResponse(cachedEntry), nil
+	}
+
 	// Gate 0a: req/s-Limiter (in-memory Token-Bucket)
 	if err := c.limiter.Wait(ctx); err != nil {
 		return nil, fmt.Errorf("rate limiter wait: %w", err)
@@ -164,7 +205,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		return nil, ctx.Err()
 	}
 
-	// Step 1: Check Rate Limit
+	// Step 2: Check Rate Limit (Legacy-Error-Limit)
 	allowed, err := c.rateLimiter.ShouldAllowRequest(ctx)
 	if err != nil {
 		c.logger.Error().Err(err).Msg("Rate limit check failed")
@@ -177,30 +218,12 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		return nil, fmt.Errorf("request blocked: rate limit critical")
 	}
 
-	// Step 2: Check Cache
-	cacheKey := cache.CacheKey{
-		Endpoint:    endpoint,
-		QueryParams: req.URL.Query(),
-	}
-	// Authentifizierte Requests: Hash des Authorization-Headers in den Key (kein Roh-Token).
-	if authHeader := req.Header.Get("Authorization"); authHeader != "" {
-		sum := sha256.Sum256([]byte(authHeader))
-		cacheKey.Auth = hex.EncodeToString(sum[:])[:16]
-	}
-
-	cachedEntry, err := c.cache.Get(ctx, cacheKey)
-	if err != nil && err != cache.ErrCacheMiss {
-		c.logger.Warn().Err(err).Str("endpoint", endpoint).Msg("Cache get error")
-	}
-
-	// Step 3: Make Conditional Request if cache hit
-	if cachedEntry != nil && cache.ShouldMakeConditionalRequest(cachedEntry) {
-		cache.AddConditionalHeaders(req, cachedEntry)
-		c.logger.Debug().
-			Str("endpoint", endpoint).
-			Str("etag", cachedEntry.ETag).
-			Msg("Making conditional request")
-	}
+	// Hinweis: Der frühere Step "Conditional Request bei Cache-Hit" entfällt —
+	// frische Einträge werden oben direkt serviert, abgelaufene löscht
+	// cache.Get (Redis-TTL räumt sie ohnehin ab). Eine Stale-with-ETag-
+	// Revalidierung (Einträge über Expires hinaus aufbewahren → 304 statt
+	// Voll-Fetch) wäre eine künftige Erweiterung der Cache-Schicht
+	// (cache.ShouldMakeConditionalRequest/AddConditionalHeaders existieren dort weiter).
 
 	// Step 4: Set User-Agent header
 	req.Header.Set("User-Agent", c.config.UserAgent)
@@ -348,28 +371,20 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		return nil, retryErr
 	}
 
-	// Step 7: Handle 304 Not Modified
+	// Step 7: Handle 304 Not Modified.
+	// Da der Client keine Conditional Requests mehr sendet (frische Einträge
+	// werden oben direkt serviert, abgelaufene löscht cache.Get), ist ein 304
+	// hier eine Protokollverletzung von ESI — fail-loud statt eines
+	// (nil, nil)-Returns aus einem nil-Cache-Eintrag.
 	if resp.StatusCode == http.StatusNotModified {
-		c.logger.Debug().Str("endpoint", endpoint).Msg("304 Not Modified - using cache")
-
-		// Update cache TTL from new expires header
-		if expiresStr := resp.Header.Get("Expires"); expiresStr != "" {
-			if newExpires, err := http.ParseTime(expiresStr); err == nil {
-				if err := c.cache.UpdateTTL(ctx, cacheKey, newExpires); err != nil {
-					c.logger.Warn().Err(err).Msg("Failed to update cache TTL")
-				}
-			}
-		}
-
-		// Return cached response
 		if cerr := resp.Body.Close(); cerr != nil {
 			c.logger.Warn().Err(cerr).Str("endpoint", endpoint).Msg("Failed to close 304 response body")
 		}
-		return c.cacheEntryToResponse(cachedEntry), nil
+		return nil, fmt.Errorf("unexpected 304 from ESI without conditional request for %s", endpoint)
 	}
 
-	// Step 8: Update Cache on success
-	if resp.StatusCode == http.StatusOK {
+	// Step 8: Update Cache on success (nur GET-Antworten sind cachebar)
+	if cacheable && resp.StatusCode == http.StatusOK {
 		entry, err := cache.ResponseToEntry(resp)
 		if err != nil {
 			// Response is still returned to the caller; it is just not cached.

--- a/pkg/client/client_integration_test.go
+++ b/pkg/client/client_integration_test.go
@@ -124,21 +124,21 @@ func TestIntegration_FullRequestFlow(t *testing.T) {
 	// Wait for cache to be written
 	time.Sleep(200 * time.Millisecond)
 
-	// Request 2: Should use cache and make conditional request
-	t.Log("Request 2: Conditional request")
+	// Request 2: Eintrag ist frisch → Fresh-Serve aus dem Cache, kein
+	// weiterer Request und kein Conditional Request.
+	t.Log("Request 2: Fresh cache hit - served without revalidation")
 	resp2, err := client.Get(ctx, "/test/endpoint")
 	if err != nil {
 		t.Fatalf("Request 2 failed: %v", err)
 	}
 	defer resp2.Body.Close()
 
-	// Should have made second request with conditional headers
-	if requestsMade != 2 {
-		t.Errorf("After request 2: requestsMade = %d, want 2", requestsMade)
+	if requestsMade != 1 {
+		t.Errorf("After request 2: requestsMade = %d, want 1 (fresh hit must not revalidate)", requestsMade)
 	}
 
-	if conditionalRequests != 1 {
-		t.Errorf("conditionalRequests = %d, want 1", conditionalRequests)
+	if conditionalRequests != 0 {
+		t.Errorf("conditionalRequests = %d, want 0 (fresh hit must not revalidate)", conditionalRequests)
 	}
 
 	// Verify cache contains the entry

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -962,3 +962,59 @@ func TestDo_429LongBlockFailsFast(t *testing.T) {
 		t.Errorf("must fail fast, took %v", elapsed)
 	}
 }
+
+// Fresh-Serve: ein noch frischer Cache-Eintrag (Expires in der Zukunft) wird
+// OHNE Netzwerk-Roundtrip serviert — das ist das Verhalten, das RespectExpires
+// verspricht. Vorher revalidierte der Client jeden frischen Treffer per
+// Conditional Request (304-Roundtrip: Latenz + 1 Token Gruppen-Rate-Limit).
+func TestDo_FreshCacheHitServesWithoutHTTP(t *testing.T) {
+	redisClient := setupTestRedis(t)
+	cfg := DefaultConfig(redisClient, "Test/1.0 (t@e.x)")
+	c, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	var httpCalls int
+	c.SetHTTPClient(&http.Client{Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+		httpCalls++
+		h := make(http.Header)
+		h.Set("Expires", time.Now().Add(5*time.Minute).Format(http.TimeFormat))
+		h.Set("ETag", `"etag-1"`)
+		h.Set("X-Pages", "7")
+		h.Set("Content-Type", "application/json")
+		return &http.Response{StatusCode: 200, Header: h, Body: io.NopCloser(strings.NewReader(`[{"id":1}]`))}, nil
+	})})
+
+	ctx := context.Background()
+
+	// Request 1: füllt den Cache (1 HTTP-Call).
+	resp1, err := c.Get(ctx, "/v1/markets/10000002/orders/")
+	if err != nil {
+		t.Fatalf("Request 1: %v", err)
+	}
+	body1, _ := io.ReadAll(resp1.Body)
+	_ = resp1.Body.Close()
+
+	// Request 2: Eintrag ist frisch — MUSS aus dem Cache kommen, 0 weitere HTTP-Calls.
+	resp2, err := c.Get(ctx, "/v1/markets/10000002/orders/")
+	if err != nil {
+		t.Fatalf("Request 2: %v", err)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	_ = resp2.Body.Close()
+
+	if httpCalls != 1 {
+		t.Errorf("httpCalls = %d, want 1 (fresh hit must not revalidate)", httpCalls)
+	}
+	if string(body2) != string(body1) {
+		t.Errorf("cached body = %q, want %q", body2, body1)
+	}
+	if resp2.StatusCode != 200 {
+		t.Errorf("cached status = %d, want 200", resp2.StatusCode)
+	}
+	// Pagination-kritisch: Header (X-Pages) müssen den Fresh-Serve überleben.
+	if got := resp2.Header.Get("X-Pages"); got != "7" {
+		t.Errorf("X-Pages = %q, want \"7\" (headers must survive cache serve)", got)
+	}
+}

--- a/tests/integration/client_test.go
+++ b/tests/integration/client_test.go
@@ -124,20 +124,21 @@ func TestFullRequestFlow(t *testing.T) {
 	// Wait for cache write
 	time.Sleep(100 * time.Millisecond)
 
-	// Request 2: Should hit cache and make conditional request
-	t.Log("Request 2: Cache hit with conditional request")
+	// Request 2: Eintrag ist frisch → Fresh-Serve aus dem Cache, kein
+	// weiterer ESI-Request und kein Conditional Request.
+	t.Log("Request 2: Fresh cache hit - served without revalidation")
 	resp2, err := c.Get(ctx, "/v1/markets/10000002/orders/")
 	if err != nil {
 		t.Fatalf("Request 2 failed: %v", err)
 	}
 	defer func() { _ = resp2.Body.Close() }()
 
-	if mockESI.GetRequestCount() != 2 {
-		t.Errorf("After request 2: ESI requests = %d, want 2", mockESI.GetRequestCount())
+	if mockESI.GetRequestCount() != 1 {
+		t.Errorf("After request 2: ESI requests = %d, want 1 (fresh hit must not revalidate)", mockESI.GetRequestCount())
 	}
 
-	if mockESI.GetConditionalCount() != 1 {
-		t.Errorf("Conditional requests = %d, want 1", mockESI.GetConditionalCount())
+	if mockESI.GetConditionalCount() != 0 {
+		t.Errorf("Conditional requests = %d, want 0 (fresh hit must not revalidate)", mockESI.GetConditionalCount())
 	}
 
 	// Verify metrics incremented
@@ -183,17 +184,17 @@ func TestCacheHit(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	// Second request - should use cache
+	// Second request - der Eintrag ist noch frisch (Expires in der Zukunft)
+	// und MUSS ohne Netzwerk-Roundtrip aus dem Cache kommen (Fresh-Serve).
 	resp2, err := c.Get(ctx, "/v1/status/")
 	if err != nil {
 		t.Fatalf("Second request failed: %v", err)
 	}
 	_ = resp2.Body.Close()
 
-	// Should have made a conditional request (304 response expected)
 	finalCount := mockESI.GetRequestCount()
-	if finalCount != 2 {
-		t.Errorf("Final ESI requests = %d, want 2 (with conditional)", finalCount)
+	if finalCount != 1 {
+		t.Errorf("Final ESI requests = %d, want 1 (fresh hit must not revalidate)", finalCount)
 	}
 }
 
@@ -239,7 +240,8 @@ func TestNotModified(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	// Second request - should get 304 and return cached data
+	// Second request - der Eintrag ist noch frisch und wird direkt aus dem
+	// Cache serviert (Fresh-Serve): gleicher Body, KEIN Conditional Request.
 	resp2, err := c.Get(ctx, "/v1/markets/10000002/orders/")
 	if err != nil {
 		t.Fatalf("Second request failed: %v", err)
@@ -247,13 +249,12 @@ func TestNotModified(t *testing.T) {
 	body2, _ := io.ReadAll(resp2.Body)
 	_ = resp2.Body.Close()
 
-	// Even though server returned 304, client should return cached body
 	if string(body2) != testData {
 		t.Errorf("Second response body = %s, want %s (cached)", string(body2), testData)
 	}
 
-	if mockESI.GetConditionalCount() != 1 {
-		t.Errorf("Conditional requests = %d, want 1", mockESI.GetConditionalCount())
+	if mockESI.GetConditionalCount() != 0 {
+		t.Errorf("Conditional requests = %d, want 0 (fresh hit must not revalidate)", mockESI.GetConditionalCount())
 	}
 }
 


### PR DESCRIPTION
## Was

**/brain-review-Vorschlag 1:** `RespectExpires` versprach „honor ESI expires" („MUST be true for ESI compliance"), wurde aber nur **validiert** — tatsächlich revalidierte der Client jeden frischen Cache-Treffer per Conditional Request: 304-Roundtrip = Latenz + 1 Token im Gruppen-Rate-Limit + Gate-Pass, pro Lookup. Warme Berechnungen (Hauling-Retry, Mining-Neuberechnung) machten dadurch hunderte unnötige ESI-Requests; eve-o-provit hat das app-seitig mit per-Request-Memoization überpflastert (CHANGELOG v0.29.0).

### Änderungen

1. **Fresh-Serve:** GET-Cache-Lookup **vor** allen Gates; frischer Eintrag (Expires in der Zukunft = CCPs Freshness-Vertrag) wird direkt aus Redis beantwortet — alle Header bleiben erhalten (`X-Pages` für Pagination explizit getestet). Abgelaufene Einträge: unverändert Voll-Fetch (kein Verlust — Redis-TTL räumte sie ohnehin ab; ein 304-Pfad für abgelaufene Einträge existierte faktisch nie, `cache.Get` löscht bei Ablauf).
2. **Caching strikt GET-only** (Lookup UND Write). Vorher floss jeder 200 in den Cache — cross-method war das harmlos, mit Fresh-Serve wäre es fatal (POST aus dem Cache „beantwortet"; exakt so im Test `TestDo_RetryResendsBody` aufgeschlagen).
3. **Conditional Requests entfernt, unerwartete 304 fail-loud** (Protokollverletzung → klarer Fehler statt potenziellem `(nil, nil)`). ETags bleiben gespeichert — Grundlage für künftige Stale-with-ETag-Revalidierung (separate Erweiterung).

## Tests

- Neu (TDD, vorher rot): `TestDo_FreshCacheHitServesWithoutHTTP` — Fresh-Hit = 0 HTTP-Calls, Body identisch, `X-Pages` überlebt.
- 4 Alt-Verhaltens-Tests auf das neue Verhalten gezogen (TestCacheHit, TestNotModified, TestFullRequestFlow, TestIntegration_FullRequestFlow — letzter auch unter `-tags=integration` lokal grün).
- `TZ=UTC go test ./...` komplett grün, golangci-lint 0 Issues.
- Doku (README-Compliance, configuration Cache-Flow, troubleshooting) auf Fresh-Serve umgestellt.

## Erwarteter Effekt in eve-o-provit

Wiederholte Berechnungen im Expires-Fenster (Markt-Orders: 5 min) fallen von ~30 s auf Sekundenbruchteile; ESI-Last und Token-Verbrauch sinken massiv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
