### PR TITLE
build(make): release + release-check Target für eve-esi-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`make release` + `make release-check` Target.** `release` transformiert den `[Unreleased]`-Block zu `[VERSION] - <Datum>` (SemVer-Format validiert, Doppel-Release verhindert) und gibt die commit/tag/push-Schritte aus — beendet die manuelle `sed`-Zeremonie. `release-check` (auch als Prereq) bricht ab, wenn `[Unreleased]` leer ist (kein Leer-Release). Angleichung an das eve-o-provit-Release-Tooling.
+
+
 ## [0.7.0] - 2026-06-07
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test test-coverage lint fmt vet clean deps tidy
+.PHONY: help test test-coverage lint fmt vet clean deps tidy release-check release
 
 GO := go
 GOFLAGS := -v
@@ -40,5 +40,25 @@ deps: ## Download dependencies
 tidy: ## Tidy go.mod
 	@echo "Tidying go.mod..."
 	$(GO) mod tidy
+
+release-check: ## Prüft, ob der [Unreleased]-Block Einträge für ein Release hat
+	@awk '/^## \[Unreleased\]/{f=1;next} /^## \[/{if(f)exit} f&&/[^[:space:]]/{found=1} END{exit !found}' CHANGELOG.md \
+		|| { echo "[make release-check] ERROR: [Unreleased] ist leer — nichts zu releasen" >&2; exit 1; }
+	@echo "[make release-check] ✅ [Unreleased] enthält Einträge"
+
+release: release-check ## Version bump: [Unreleased] -> [VERSION] (Beispiel: make release VERSION=0.7.1)
+	@if [ -z "$(VERSION)" ]; then \
+		echo "[make release] ERROR: VERSION Parameter fehlt (Beispiel: make release VERSION=0.7.1)" >&2; \
+		exit 1; \
+	fi
+	@echo "$(VERSION)" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$$' \
+		|| { echo "[make release] ERROR: VERSION '$(VERSION)' ist kein SemVer (X.Y.Z)" >&2; exit 1; }
+	@grep -qE '^## \[$(VERSION)\]' CHANGELOG.md \
+		&& { echo "[make release] ERROR: Version $(VERSION) steht bereits im CHANGELOG" >&2; exit 1; } || true
+	@echo "[make release] Bump auf $(VERSION)..."
+	@sed -i "s/^## \[Unreleased\]/## [Unreleased]\n\n## [$(VERSION)] - $$(date +%Y-%m-%d)/" CHANGELOG.md
+	@echo "[make release] ✅ CHANGELOG aktualisiert — nächste Schritte:"
+	@echo "    git add CHANGELOG.md && git commit -m 'chore(release): v$(VERSION)'"
+	@echo "    git tag v$(VERSION) && git push origin main v$(VERSION)"
 
 .DEFAULT_GOAL := help


### PR DESCRIPTION
**/brain-review-Vorschlag:** eve-esi-client hatte kein `release`-Target — v0.5.0/v0.5.1/v0.6.0/v0.7.0 wurden je per Hand-`sed` aufs CHANGELOG geschnitten.

- `make release VERSION=x.y.z`: `[Unreleased]` → `[x.y.z] - <Datum>`, validiert SemVer-Format, verweigert bereits vergebene Version, gibt commit/tag/push-Schritte aus.
- `make release-check` (auch Prereq von `release`): bricht ab, wenn `[Unreleased]` leer ist — kein Leer-Release (brain-audit-Lektion).
- Angleichung an das eve-o-provit-Tooling.

Verifiziert: release-check schlägt bei leerem Block fehl, ist mit Einträgen grün; Transform-Trockenlauf korrekt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)